### PR TITLE
Update AddBlipForRadius

### DIFF
--- a/HUD/AddBlipForRadius.md
+++ b/HUD/AddBlipForRadius.md
@@ -5,14 +5,15 @@ ns: HUD
 
 ```c
 // 0x46818D79B1F7499A 0x4626756C
-Blip ADD_BLIP_FOR_RADIUS(float posX, float posY, float posZ, float radius);
+Blip ADD_BLIP_FOR_RADIUS(float posX, float posY, float posZ, float diameter);
 ```
 
 
 ## Parameters
-* **posX**: 
-* **posY**: 
-* **posZ**: 
-* **radius**: 
+* **posX**: the x coordinate of the blip
+* **posY**: the y coordinate of the blip
+* **posZ**: the z coordinate of the blip
+* **diameter**: the diameter of the blip, double the radius.
 
 ## Return value
+the handle of the created blip.


### PR DESCRIPTION
looks like AddBlipForRadius actually adds blips given their diameter, fixed that in the docs.