### PR TITLE
These natives are all NOP natives, they don't do anything.

### DIFF
--- a/AUDIO/N_0x02e93c796abd3a97.md
+++ b/AUDIO/N_0x02e93c796abd3a97.md
@@ -8,6 +8,7 @@ ns: AUDIO
 void _0x02E93C796ABD3A97(BOOL p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/AUDIO/RegisterScriptWithAudio.md
+++ b/AUDIO/RegisterScriptWithAudio.md
@@ -8,6 +8,7 @@ ns: AUDIO
 void REGISTER_SCRIPT_WITH_AUDIO(int p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/AUDIO/UnregisterScriptWithAudio.md
+++ b/AUDIO/UnregisterScriptWithAudio.md
@@ -8,6 +8,8 @@ ns: AUDIO
 void UNREGISTER_SCRIPT_WITH_AUDIO();
 ```
 
+**This native does absolutely nothing, just a nullsub**
+
 ```
 On last-gen this just runs blr and this func is called by several other functions other then the native's table.  
 ```

--- a/BRAIN/SetNextDesiredMoveState.md
+++ b/BRAIN/SetNextDesiredMoveState.md
@@ -8,6 +8,8 @@ ns: BRAIN
 void SET_NEXT_DESIRED_MOVE_STATE(float p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
+
 ```
 Not used in the scripts.  
 Bullshit! It's used in spawn_activities  

--- a/CAM/N_0xccd078c2665d2973.md
+++ b/CAM/N_0xccd078c2665d2973.md
@@ -8,6 +8,7 @@ ns: CAM
 void _0xCCD078C2665D2973(BOOL p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/GRAPHICS/N_0x61f95e5bb3e0a8c6.md
+++ b/GRAPHICS/N_0x61f95e5bb3e0a8c6.md
@@ -8,6 +8,7 @@ ns: GRAPHICS
 void _0x61F95E5BB3E0A8C6(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/HUD/ClearReminderMessage.md
+++ b/HUD/ClearReminderMessage.md
@@ -9,4 +9,4 @@ aliases: ["0xB57D8DD645CFA2CF"]
 void CLEAR_REMINDER_MESSAGE();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/HUD/N_0x211c4ef450086857.md
+++ b/HUD/N_0x211c4ef450086857.md
@@ -8,4 +8,4 @@ ns: HUD
 void _0x211C4EF450086857();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/HUD/N_0xd2049635deb9c375.md
+++ b/HUD/N_0xd2049635deb9c375.md
@@ -8,4 +8,4 @@ ns: HUD
 void _0xD2049635DEB9C375();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/HUD/SetMultiplayerHudCash.md
+++ b/HUD/SetMultiplayerHudCash.md
@@ -8,6 +8,7 @@ ns: HUD
 void SET_MULTIPLAYER_HUD_CASH(int p0, int p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/HUD/SetTextEdge.md
+++ b/HUD/SetTextEdge.md
@@ -8,6 +8,7 @@ ns: HUD
 void SET_TEXT_EDGE(int p0, int r, int g, int b, int a);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/HUD/SetTextProportional.md
+++ b/HUD/SetTextProportional.md
@@ -8,6 +8,7 @@ ns: HUD
 void SET_TEXT_PROPORTIONAL(BOOL p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0x23227df0b2115469.md
+++ b/MISC/N_0x23227df0b2115469.md
@@ -8,4 +8,4 @@ ns: MISC
 void _0x23227DF0B2115469();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/MISC/N_0x31125fd509d9043f.md
+++ b/MISC/N_0x31125fd509d9043f.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0x31125FD509D9043F(Any* p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0x4dcdf92bf64236cd.md
+++ b/MISC/N_0x4dcdf92bf64236cd.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0x4DCDF92BF64236CD(char* p0, char* p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0x703cc7f60cbb2b57.md
+++ b/MISC/N_0x703cc7f60cbb2b57.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0x703CC7F60CBB2B57(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0x8951eb9c6906d3c8.md
+++ b/MISC/N_0x8951eb9c6906d3c8.md
@@ -8,4 +8,4 @@ ns: MISC
 void _0x8951EB9C6906D3C8();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/MISC/N_0x97e7e2c04245115b.md
+++ b/MISC/N_0x97e7e2c04245115b.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0x97E7E2C04245115B(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0xba4b8d83bdc75551.md
+++ b/MISC/N_0xba4b8d83bdc75551.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0xBA4B8D83BDC75551(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0xeb078ca2b5e82add.md
+++ b/MISC/N_0xeb078ca2b5e82add.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0xEB078CA2B5E82ADD(Any p0, Any p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/MISC/N_0xebd3205a207939ed.md
+++ b/MISC/N_0xebd3205a207939ed.md
@@ -8,6 +8,7 @@ ns: MISC
 void _0xEBD3205A207939ED(Any* p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/NETWORK/N_0x5c497525f803486b.md
+++ b/NETWORK/N_0x5c497525f803486b.md
@@ -8,4 +8,5 @@ ns: NETWORK
 void _0x5C497525F803486B();
 ```
 
+**This native does absolutely nothing, just a nullsub**
 

--- a/NETWORK/N_0x6bff5f84102df80a.md
+++ b/NETWORK/N_0x6bff5f84102df80a.md
@@ -8,6 +8,7 @@ ns: NETWORK
 void _0x6BFF5F84102DF80A(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/NETWORK/N_0x966dd84fb6a46017.md
+++ b/NETWORK/N_0x966dd84fb6a46017.md
@@ -8,4 +8,4 @@ ns: NETWORK
 void _0x966DD84FB6A46017();
 ```
 
-
+**This native does absolutely nothing, just a nullsub**

--- a/NETWORK/N_0xb606e6cc59664972.md
+++ b/NETWORK/N_0xb606e6cc59664972.md
@@ -8,6 +8,7 @@ ns: NETWORK
 void _0xB606E6CC59664972(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/NETWORK/NetworkBlockInvites_2.md
+++ b/NETWORK/NetworkBlockInvites_2.md
@@ -9,6 +9,7 @@ aliases: ["0x4A9FDE3A5A6D0437"]
 void _NETWORK_BLOCK_INVITES_2(BOOL p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/NETWORK/NetworkSetRichPresence_2.md
+++ b/NETWORK/NetworkSetRichPresence_2.md
@@ -9,6 +9,8 @@ aliases: ["0x3E200C2BCF4164EB"]
 void _NETWORK_SET_RICH_PRESENCE_2(int p0, char* gxtLabel);
 ```
 
+**This native does absolutely nothing, just a nullsub**
+
 ```
 NETWORK_SET_RICH_PRESENCE but for PlayStation? (On PC it's a nullsub)  
 ```

--- a/PAD/N_0x14d29bb12d47f68c.md
+++ b/PAD/N_0x14d29bb12d47f68c.md
@@ -8,6 +8,7 @@ ns: PAD
 void _0x14D29BB12D47F68C(Any p0, Any p1, Any p2, Any p3, Any p4);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/PED/N_0x1216e0bfa72cc703.md
+++ b/PED/N_0x1216e0bfa72cc703.md
@@ -8,6 +8,7 @@ ns: PED
 void _0x1216E0BFA72CC703(Any p0, Any p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/PED/N_0xb282749d5e028163.md
+++ b/PED/N_0xb282749d5e028163.md
@@ -8,6 +8,7 @@ ns: PED
 void _0xB282749D5E028163(Any p0, Any p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/PED/SetPedPlaysHeadOnHornAnimWhenDiesInVehicle.md
+++ b/PED/SetPedPlaysHeadOnHornAnimWhenDiesInVehicle.md
@@ -8,6 +8,8 @@ ns: PED
 void SET_PED_PLAYS_HEAD_ON_HORN_ANIM_WHEN_DIES_IN_VEHICLE(Ped ped, BOOL toggle);
 ```
 
+**This native does absolutely nothing, just a nullsub**
+
 ```
 Points to the same function as for example GET_RANDOM_VEHICLE_MODEL_IN_MEMORY and it does absolutely nothing.  
 ```

--- a/RECORDING/N_0x66972397e0757e7a.md
+++ b/RECORDING/N_0x66972397e0757e7a.md
@@ -8,6 +8,7 @@ ns: RECORDING
 void _0x66972397E0757E7A(Any p0, Any p1, Any p2);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/RENDERING/N_0x7e2bd3ef6c205f09.md
+++ b/RENDERING/N_0x7e2bd3ef6c205f09.md
@@ -8,6 +8,8 @@ ns: RENDERING
 void _0x7E2BD3EF6C205F09(char* p0, BOOL p1);
 ```
 
+**This native does absolutely nothing, just a nullsub**
+
 ```
 Something to do with phone cameras.  
 startup.c4:  

--- a/STATS/PlaystatsOddjobDone.md
+++ b/STATS/PlaystatsOddjobDone.md
@@ -8,6 +8,7 @@ ns: STATS
 void PLAYSTATS_ODDJOB_DONE(Any p0, Any p1, Any p2);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 

--- a/STREAMING/N_0x4e52e752c76e7e7a.md
+++ b/STREAMING/N_0x4e52e752c76e7e7a.md
@@ -8,6 +8,7 @@ ns: STREAMING
 void _0x4E52E752C76E7E7A(Any p0);
 ```
 
+**This native does absolutely nothing, just a nullsub**
 
 ## Parameters
 * **p0**: 


### PR DESCRIPTION
This was noticed by Disquse, I've just added some comments to the description of these natives (skipped some natives that weren't even added to the reference and also skipped natives that already had a comment in the description noting that that function doesn't do anything).

Natives that don't exist on the natives reference that I've skipped:
```
0x36DE109527A2C0C4
0x6FD992C4A1C1B986
0x47AED84213A47510
0xCD0F5B5D932AE473
0x2555CF7DA5473794
0x82E0AC411E41A5B4
0x99A05839C46CE316
0xAEDF1BC1C133D6E3
```

List of all NOP natives discovered by Disquse:
```
0x7E2BD3EF6C205F09
0x703CC7F60CBB2B57
_LOG_DEBUG_INFO
NETWORK_SET_RICH_PRESENCE
0x5C497525F803486B
GET_RANDOM_VEHICLE_MODEL_IN_MEMORY
DRAW_DEBUG_LINE
SET_NEXT_DESIRED_MOVE_STATE
SET_PED_PLAYS_HEAD_ON_HORN_ANIM_WHEN_DIES_IN_VEHICLE
0xCCD078C2665D2973
0x36DE109527A2C0C4
0x66972397E0757E7A
0x211C4EF450086857
0x208784099002BC30
SET_DITCH_POLICE_MODELS
0xB282749D5E028163
CLEAR_REMINDER_MESSAGE
PLAYSTATS_ODDJOB_DONE
_NETWORK_SET_RICH_PRESENCE_2
0xD2049635DEB9C375
0x6FD992C4A1C1B986
DRAW_DEBUG_BOX
DRAW_DEBUG_CROSS
0x47AED84213A47510
0x6BFF5F84102DF80A
0xCD0F5B5D932AE473
0x4E52E752C76E7E7A
SET_MULTIPLAYER_HUD_CASH
SET_TEXT_PROPORTIONAL
DRAW_DEBUG_TEXT_2D
0x61F95E5BB3E0A8C6
REGISTER_SCRIPT_WITH_AUDIO
DRAW_DEBUG_SPHERE
0x14D29BB12D47F68C
0x2555CF7DA5473794
0x97E7E2C04245115B
SET_TEXT_EDGE
0xBA4B8D83BDC75551
0x82E0AC411E41A5B4
SET_DEBUG_LINES_AND_SPHERES_DRAWING_ACTIVE
0x1216E0BFA72CC703
0x02E93C796ABD3A97
0x99A05839C46CE316
DRAW_DEBUG_LINE_WITH_TWO_COLOURS
SET_CAM_DEBUG_NAME
SET_PED_NAME_DEBUG
0x4DCDF92BF64236CD
0x31125FD509D9043F
SET_VEHICLE_NAME_DEBUG
DRAW_DEBUG_TEXT
0x966DD84FB6A46017
0xEB078CA2B5E82ADD
0xB264C4D2F2B0A78B
UNREGISTER_SCRIPT_WITH_AUDIO
0xEBD3205A207939ED
_NETWORK_BLOCK_INVITES_2
0xAEDF1BC1C133D6E3
0xB606E6CC59664972
0x8951EB9C6906D3C8
0x23227DF0B2115469
```