### PR TITLE
Describe usage of SET_VEHICLE_BRAKE_LIGHTS.

### DIFF
--- a/VEHICLE/SetVehicleBrakeLights.md
+++ b/VEHICLE/SetVehicleBrakeLights.md
@@ -13,3 +13,7 @@ void SET_VEHICLE_BRAKE_LIGHTS(Vehicle vehicle, BOOL toggle);
 * **vehicle**: 
 * **toggle**: 
 
+//not a "toggle",
+//must be called on tick
+
+


### PR DESCRIPTION
Must be called on tick, parameter name is misleading.