### PR TITLE
Create N_0x45f35c0edc33b03b

### DIFF
--- a/NETWORK/N_0x45f35c0edc33b03b
+++ b/NETWORK/N_0x45f35c0edc33b03b
@@ -1,11 +1,11 @@
 ---
 ns: NETWORK
 ---
-## 0x45F35C0EDC33B03B
+## _0x45F35C0EDC33B03B
 
 ```c
-// N_0x45f35c0edc33b03b
-void 0x45F35C0EDC33B03B(Entity entity, Hash model, int netScene, char* animDict, char* animName, float speed, float speedMulitiplier, int flag);
+// 0x45F35C0EDC33B03B
+void _0x45F35C0EDC33B03B(Entity entity, Hash model, int netScene, char* animDict, char* animName, float speed, float speedMulitiplier, int flag);
 ```
 
 ## Parameters

--- a/NETWORK/N_0x45f35c0edc33b03b
+++ b/NETWORK/N_0x45f35c0edc33b03b
@@ -1,0 +1,20 @@
+---
+ns: NETWORK
+---
+## 0x45F35C0EDC33B03B
+
+```c
+// N_0x45f35c0edc33b03b
+void 0x45F35C0EDC33B03B(Entity entity, Hash model, int netScene, char* animDict, char* animName, float speed, float speedMulitiplier, int flag);
+```
+
+## Parameters
+* **entity**: 
+* **model**: 
+* **netScene**: 
+* **animDict**: 
+* **animName**: 
+* **speed**: 
+* **speedMulitiplier**: 
+* **flag**: 
+


### PR DESCRIPTION
1737 native

Similar structure as NetworkAddEntityToSynchronisedScene but it includes this time a hash.
In `casino_slots` it is used one time in a synced scene involving a ped and the slot machine?