### PR TITLE
Fix return value of GetRainLevel

### DIFF
--- a/MISC/GetRainLevel.md
+++ b/MISC/GetRainLevel.md
@@ -5,7 +5,7 @@ ns: MISC
 
 ```c
 // 0x96695E368AD855F3 0xC9F67F28
-Any* GET_RAIN_LEVEL();
+float GET_RAIN_LEVEL();
 ```
 
 


### PR DESCRIPTION
Tested today, this native only return a float, and the max value is 1.0