### PR TITLE
Update SetRoadsInArea.md

### DIFF
--- a/PATHFIND/SetRoadsInArea.md
+++ b/PATHFIND/SetRoadsInArea.md
@@ -5,7 +5,7 @@ ns: PATHFIND
 
 ```c
 // 0xBF1A602B5BA52FEE 0xEBC7B918
-void SET_ROADS_IN_AREA(float x1, float y1, float z1, float x2, float y2, float z2, BOOL unknown1, BOOL unknown2);
+void SET_ROADS_IN_AREA(float x1, float y1, float z1, float x2, float y2, float z2, BOOL nodeEnabled, BOOL unknown2);
 ```
 
 ```
@@ -19,6 +19,6 @@ void SET_ROADS_IN_AREA(float x1, float y1, float z1, float x2, float y2, float z
 * **x2**: 
 * **y2**: 
 * **z2**: 
-* **unknown1**: 
+* **nodeEnabled**: 
 * **unknown2**: 
 

--- a/PATHFIND/SetRoadsInArea.md
+++ b/PATHFIND/SetRoadsInArea.md
@@ -8,9 +8,14 @@ ns: PATHFIND
 void SET_ROADS_IN_AREA(float x1, float y1, float z1, float x2, float y2, float z2, BOOL nodeEnabled, BOOL unknown2);
 ```
 
-```
-/* Corrected conflicting parameter names */  
-```
+When this is set to false, all nodes in the area get disabled.
+
+`GET_VEHICLE_NODE_IS_SWITCHED_OFF` returns true afterwards.
+
+If it's true,
+
+`GET_VEHICLE_NODE_IS_SWITCHED_OFF` returns false.
+
 
 ## Parameters
 * **x1**: 


### PR DESCRIPTION
When this is set to false, all nodes in the area get disabled.

`GET_VEHICLE_NODE_IS_SWITCHED_OFF` returns true afterwards.

If it's true,

`GET_VEHICLE_NODE_IS_SWITCHED_OFF` returns false.