### PR TITLE
CFX: Add missing drawing natives for RDR3

### DIFF
--- a/CFX/DrawLine.md
+++ b/CFX/DrawLine.md
@@ -1,0 +1,24 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## DRAW_LINE
+
+```c
+void DRAW_LINE(float x1, float y1, float z1, float x2, float y2, float z2, int red, int green, int blue, int alpha);
+```
+
+Draws a depth-tested line from one point to another.
+
+## Parameters
+* **x1**: The X position of first coordinate.
+* **y1**: The Y position of first coordinate.
+* **z1**: The Z position of first coordinate.
+* **x2**: The X position of second coordinate.
+* **y2**: The Y position of second coordinate.
+* **z2**: The Z position of second coordinate.
+* **red**: The red color value from 0 to 255.
+* **green**: The green color value from 0 to 255.
+* **blue**: The blue color value from 0 to 255.
+* **alpha**: The alpha value from 0 to 255.

--- a/CFX/DrawPoly.md
+++ b/CFX/DrawPoly.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## DRAW_POLY
+
+```c
+void DRAW_POLY(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3, int red, int green, int blue, int alpha);
+```
+
+Draws a depth-tested polygon with 3 points.
+
+## Parameters
+* **x1**: The X position of first coordinate.
+* **y1**: The Y position of first coordinate.
+* **z1**: The Z position of first coordinate.
+* **x2**: The X position of second coordinate.
+* **y2**: The Y position of second coordinate.
+* **z2**: The Z position of second coordinate.
+* **x3**: The X position of third coordinate.
+* **y3**: The Y position of third coordinate.
+* **z3**: The Z position of third coordinate.
+* **red**: The red color value from 0 to 255.
+* **green**: The green color value from 0 to 255.
+* **blue**: The blue color value from 0 to 255.
+* **alpha**: The alpha value from 0 to 255.


### PR DESCRIPTION
```cpp
void DRAW_LINE(float x1, float y1, float z1, float x2, float y2, float z2, int red, int green, int blue, int alpha);
void DRAW_POLY(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3, int red, int green, int blue, int alpha);
```

Implemented in https://github.com/citizenfx/fivem/pull/323