### PR TITLE
Update SetGameplayCamRelativePitch.md

### DIFF
--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -11,8 +11,6 @@ void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float angle, float scalingFactor);
 This native sets the camera's pitch (rotation on the x-axis).
 Parameters:  
 x = pitches the camera on the x axis.  
-scalingFactor = always seems to be hex 0x3F800000 in native calls (1.000000 float). values of 1.0   
-```
 
 ## Parameters
 * **angle**: the angle to rotate the camera by

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -15,5 +15,5 @@ scalingFactor = always seems to be hex 0x3F800000 in native calls (1.000000 floa
 ```
 
 ## Parameters
-* **x**: 
+* **angle**: the angle to rotate the camera by
 * **scalingFactor**: always seems to be set to 1.0 in native calls

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -8,7 +8,7 @@ ns: CAM
 void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float x, float scalingFactor);
 ```
 
-Sets the camera pitch.  
+This native sets the camera's pitch (rotation on the x-axis).
 Parameters:  
 x = pitches the camera on the x axis.  
 scalingFactor = always seems to be hex 0x3F800000 in native calls (1.000000 float). values of 1.0   

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -8,7 +8,6 @@ ns: CAM
 void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float x, float scalingFactor);
 ```
 
-```
 Sets the camera pitch.  
 Parameters:  
 x = pitches the camera on the x axis.  

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -5,17 +5,17 @@ ns: CAM
 
 ```c
 // 0x6D0858B8EDFD2B7D 0x6381B963
-void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float x, float Value2);
+void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float x, float scalingFactor);
 ```
 
 ```
 Sets the camera pitch.  
 Parameters:  
 x = pitches the camera on the x axis.  
-Value2 = always seems to be hex 0x3F800000 (1.000000 float).  
+scalingFactor = always seems to be hex 0x3F800000 in native calls (1.000000 float). values of 1.0   
 ```
 
 ## Parameters
 * **x**: 
-* **Value2**: 
+* **scalingFactor**: 
 

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -17,5 +17,4 @@ scalingFactor = always seems to be hex 0x3F800000 in native calls (1.000000 floa
 
 ## Parameters
 * **x**: 
-* **scalingFactor**: 
-
+* **scalingFactor**: always seems to be set to 1.0 in native calls

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -9,8 +9,6 @@ void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float angle, float scalingFactor);
 ```
 
 This native sets the camera's pitch (rotation on the x-axis).
-Parameters:  
-x = pitches the camera on the x axis.  
 
 ## Parameters
 * **angle**: the angle to rotate the camera by

--- a/CAM/SetGameplayCamRelativePitch.md
+++ b/CAM/SetGameplayCamRelativePitch.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0x6D0858B8EDFD2B7D 0x6381B963
-void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float x, float scalingFactor);
+void SET_GAMEPLAY_CAM_RELATIVE_PITCH(float angle, float scalingFactor);
 ```
 
 This native sets the camera's pitch (rotation on the x-axis).


### PR DESCRIPTION
As discovered in https://twitch.tv/videos/620187110, the value2 seems to be some sort of scaling factor. 1.0 slammed the screen around while lower values (around 0.8) seemed to be a bit more sane motion.