### PR TITLE
rotation orders

### DIFF
--- a/ENTITY/GetEntityRotation.md
+++ b/ENTITY/GetEntityRotation.md
@@ -10,24 +10,23 @@ Vector3 GET_ENTITY_ROTATION(Entity entity, int rotationOrder);
 ```
 
 ```
-rotationOrder refers to the order yaw pitch roll is applied
-value ranges from 0 to 5. What you use for rotationOrder when getting must be the same as rotationOrder when setting the rotation.
-Unsure what value corresponds to what rotation order, more testing will be needed for that.
-------
-rotationOrder is usually 2 in scripts
-------
-ENTITY::GET_ENTITY_ROTATION(Any p0, false or true);
-if false than return from -180 to 180
-if true than return from -90 to 90
----
-As said above, the value of p1 affects the outcome. R* uses 1 and 2 instead of 0 and 1, so I marked it as an int.
+rotationOrder refers to the order yaw pitch roll is applied; value ranges from 0 to 5 and is usually *2* in scripts.
+
+What you use for rotationOrder when getting must be the same as rotationOrder when setting the rotation.
+
 What it returns is the yaw on the z part of the vector, which makes sense considering R* considers z as vertical. Here's a picture for those of you who don't understand pitch, yaw, and roll:
 www.allstar.fiu.edu/aero/images/pic5-1.gif
-I don't know why it returns a Vec3, but sometimes the values x and y go negative, yet they're always zero. Just use GET_ENTITY_PITCH and GET_ENTITY_ROLL for pitch and roll.
 ```
 
-## Parameters
+### Rotation Orders
+**0**: ZYX - Rotate around the z-axis, then the y-axis and finally the x-axis.
+**1**: YZX - Rotate around the y-axis, then the z-axis and finally the x-axis.
+**2**: ZXY - Rotate around the z-axis, then the x-axis and finally the y-axis.
+**3**: XZY - Rotate around the x-axis, then the z-axis and finally the y-axis.
+**4**: YXZ - Rotate around the y-axis, then the x-axis and finally the z-axis.
+**5**: XYZ - Rotate around the x-axis, then the y-axis and finally the z-axis.
 
+## Parameters
 - **entity**: The entity to get the rotation for.
 - **rotationOrder**: The order yaw, pitch and roll is applied. Usually 2.
 

--- a/ENTITY/SetEntityRotation.md
+++ b/ENTITY/SetEntityRotation.md
@@ -9,11 +9,9 @@ void SET_ENTITY_ROTATION(Entity entity, float pitch, float roll, float yaw, int 
 ```
 
 ```
-rotationOrder refers to the order yaw pitch roll is applied  
-value ranges from 0 to 5. What you use for rotationOrder when setting must be the same as rotationOrder when getting the rotation.   
-Unsure what value corresponds to what rotation order, more testing will be needed for that.  
-For the most part R* uses 1 or 2 as the order.  
-p5 is usually set as true  
+rotationOrder refers to the order yaw pitch roll is applied, see [GET_ENTITY_ROTATION](#_0xAFBD61CC738D9EB9)
+
+p5 is usually set as true
 ```
 
 ## Parameters


### PR DESCRIPTION
Given the number of natives that accept a rotation order, it may be easier to create a subsection in the docs, with a primer on rotations (Scott Elk, how is your math?), and simply reference that.

Pulled from 0x140A0E67C (1604 retail): here are the snippets that provide meaning (everything else in those functions revolve around dealing with edge cases and the not-unique-solutions around +1/-1).
- 0 = Euler ZYX = ``atan2f(v14, v18), asinf(-v17), atan2f(v27, v26)``
- 1 = Euler YZX = ``atan2f(v26, v18), atan2f(v23, v14), asinf(v28)``
- 2 = Euler ZXY = ``asinf(v16), atan2f((v25 = -v18)), v20), atan2f((v23 = -v29), v30)``
- 3 = Euler XZY = ``atan2f(v17, v14), atan2f(v21, v19), asinf(-v31)``
- 4 = Euler YXZ = ``asinf(-v16), atan2f(v18, v20), atan2f(Y, v30)``
- 5 = Euler XYZ = ``atan2f((v25 = -v18), v20), asinf(v16), atan2f((v23 = -v30), a1a)``

These can be cross referenced.