### PR TITLE
Clarifies prerequisites to displaying player blip labels on bigmap

### DIFF
--- a/HUD/N_0x82cedc33687e1f50.md
+++ b/HUD/N_0x82cedc33687e1f50.md
@@ -11,6 +11,8 @@ Toggles whether or not name labels are shown on the expanded minimap next to pla
 Doesn't need to be called every frame.  
 Preview: https://i.imgur.com/DfqKWfJ.png
 
+Make sure to call [SetBlipCategory](https://runtime.fivem.net/doc/natives/?_0x234CDD44D996FD9A) with index 7 for this to work on the desired blip.
+
 
 ## Parameters
 * **p0**: the toggle boolean

--- a/HUD/SetBlipCategory.md
+++ b/HUD/SetBlipCategory.md
@@ -25,6 +25,7 @@ Any other value behaves like `index = 1`, `index` wraps around after 255
 
 Blips with categories `7`, `10` or `11` will all show under the specific categories listing in the map legend, regardless of sprite or name.
 
+Category needs to be `7` in order for blip names to show on the expanded minimap when using [0x82CEDC33687E1F50](https://runtime.fivem.net/doc/natives/?_0x82CEDC33687E1F50).
 
 **Legend entries**
 


### PR DESCRIPTION
If you try to display player blip labels on the expanded map using [0x82CEDC33687E1F50](https://runtime.fivem.net/doc/natives/?_0x82CEDC33687E1F50), you need to call [SetBlipCategory](https://runtime.fivem.net/doc/natives/?_0x234CDD44D996FD9A) with index 7 as otherwise the labels won't display. Here's a screenshot of the expanded minimap with a blip of category 2: 
![image](https://user-images.githubusercontent.com/4386963/103934464-e94cf100-511c-11eb-962c-7431a83d7c18.png)

Here's category 7 (working as expected) 
![image](https://user-images.githubusercontent.com/4386963/103934543-0d103700-511d-11eb-938a-c778dfae7e88.png)

This PR just clarifies that requirement.

