### PR TITLE
added note about parameter types

### DIFF
--- a/STREAMING/RequestModel.md
+++ b/STREAMING/RequestModel.md
@@ -11,6 +11,9 @@ void REQUEST_MODEL(Hash model);
 ```
 Request a model to be loaded into memory.
 ```
+**Note**: the function **also** accepts a model passed by ped name. (string)
+e.g.: RequestModel('ig_abigail')
+Same as: RequestModel(0x400AEC41)
 
 ## Parameters
 * **model**: 


### PR DESCRIPTION
The function also accepts ped names passed as strings, not only model hashes.