### PR TITLE
Update SetVehicleIndividualDoorsLocked.md

### DIFF
--- a/VEHICLE/SetVehicleIndividualDoorsLocked.md
+++ b/VEHICLE/SetVehicleIndividualDoorsLocked.md
@@ -14,5 +14,5 @@ See eDoorId declared in [`SET_VEHICLE_DOOR_SHUT`](#_0x93D9BD300D7789E5)
 ## Parameters
 * **vehicle**: 
 * **doorIndex**: 
-* **destroyType**: 
+* **destroyType**: 1: opens on damage, 2: breaks on damage
 


### PR DESCRIPTION
Updated destroyType since https://docs.fivem.net/natives/?_0xBE70724027F85BCD now refers to it as SetVehicleIndividualDoorsLocked and is absent some vital operational info

Before you submit this PR, please make sure:

- You have read the contribution guidelines
- You include an example that validates your change
- Your English is grammatically correct
