### PR TITLE
Update ScaleformMovieMethodAddParamPlayerNameString.md

### DIFF
--- a/GRAPHICS/ScaleformMovieMethodAddParamPlayerNameString.md
+++ b/GRAPHICS/ScaleformMovieMethodAddParamPlayerNameString.md
@@ -17,3 +17,12 @@ When switching with a controller, the icons update and become the controller's i
 ## Parameters
 * **string**: 
 
+```lua
+--You can push Control names directly.
+ScaleformMovieMethodAddParamPlayerNameString("~INPUT_ENTER~")
+
+--Works with custom keybinds too:
+ScaleformMovieMethodAddParamPlayerNameString("~INPUT_F53DC64D~") --+handsup command, added with RegisterKeyMapping()
+
+```
+


### PR DESCRIPTION
Added lua examples to highlight the fact that you can use the control name directly, and don't need to get the hash with GetControlInstructionalButton()
