### PR TITLE
Rename AttachEntityToEntity parameter

### DIFF
--- a/ENTITY/AttachEntityToEntity.md
+++ b/ENTITY/AttachEntityToEntity.md
@@ -5,7 +5,7 @@ ns: ENTITY
 
 ```c
 // 0x6B9BBD38AB0796DF 0xEC024237
-void ATTACH_ENTITY_TO_ENTITY(Entity entity1, Entity entity2, int boneIndex, float xPos, float yPos, float zPos, float xRot, float yRot, float zRot, BOOL p9, BOOL useSoftPinning, BOOL collision, BOOL isPed, int vertexIndex, BOOL fixedRot);
+void ATTACH_ENTITY_TO_ENTITY(Entity entity1, Entity entity2, int boneIndex, float xPos, float yPos, float zPos, float xRot, float yRot, float zRot, BOOL p9, BOOL useSoftPinning, BOOL collision, BOOL isPed, int rotationOrder, BOOL fixedRot);
 ```
 
 ```
@@ -32,6 +32,6 @@ fixedRot - if false it ignores entity vector
 * **useSoftPinning**: 
 * **collision**: 
 * **isPed**: 
-* **vertexIndex**: 
+* **rotationOrder**: The order in which the rotation is applied. See [`GET_ENTITY_ROTATION`](#_0xAFBD61CC738D9EB9)
 * **fixedRot**: 
 


### PR DESCRIPTION
Seems to be the rotation order (like in [GET_ENTITY_ROTATION](https://runtime.fivem.net/doc/natives/?_0xAFBD61CC738D9EB9)) not the "vertexIndex".

I'm not sure if I'm supposed to change the parameter name in the description code block also or even in the block at the top because of the native db imports. Tell me how it's supposed to look and I'll change it.