### PR TITLE
Update PointCamAtEntity.md

### DIFF
--- a/CAM/PointCamAtEntity.md
+++ b/CAM/PointCamAtEntity.md
@@ -8,15 +8,21 @@ ns: CAM
 void POINT_CAM_AT_ENTITY(Cam cam, Entity entity, float p2, float p3, float p4, BOOL p5);
 ```
 
-```
-p5 always seems to be 1 i.e TRUE  
-```
+Points the camera at the specified entity.
+
+Offset works like [GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS](#_0x1899F328B0E12848).
 
 ## Parameters
-* **cam**: 
-* **entity**: 
-* **p2**: 
-* **p3**: 
-* **p4**: 
-* **p5**: 
+* **cam**: Cam (Return value of CREATE_CAM or CREATE_CAM_WITH_PARAMS).
+* **entity**: Entity for the camera to point at.
+* **offsetX**: X offset for the camera (left/right).
+* **offsetY**: Y offset for the camera (forward/backward).
+* **offsetZ**: Z offset for the camera (up/down).
+* **p5**: Always seems to be 1 (true).
 
+## Examples
+```lua
+local cam = CreateCameraWithParams("DEFAULT_SCRIPTED_CAMERA", GetEntityCoords(PlayerPedId()), 0.0, 0.0, 0.0, 90.0, true, 2)
+PointCamAtEntity(cam, PlayerPedId(), 0.0, 0.0, 0.0, true)
+RenderScriptCams(true, false, 0, true, true)
+```


### PR DESCRIPTION
Named unknown parameters for PointCamAtEntity.

P2, P3 and P4 are the XYZ offset of the entity.

Code to test:
Camera points at the marker, therefor P2, P3 and P4 are entity offsets.

```lua
local offset = vec3(1.0, 0.0, 0.0)
local cam = CreateCameraWithParams("DEFAULT_SCRIPTED_CAMERA", GetEntityCoords(PlayerPedId()), 0.0, 0.0, 0.0, 90.0, true, 2)
PointCamAtEntity(cam, PlayerPedId(), offset, true)
RenderScriptCams(true, false, 0, true, true)

Citizen.CreateThread(function()
  while true do
    Citizen.Wait(0)
    local coords = GetOffsetFromEntityInWorldCoords(PlayerPedId(), offset)
    DrawMarker(0, coords, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.5, 255, 255, 255, 255)
  end
end)
```
