### PR TITLE
Function limitation

### DIFF
--- a/GRAPHICS/SetDrawOrigin.md
+++ b/GRAPHICS/SetDrawOrigin.md
@@ -23,6 +23,8 @@ Result: www11.pic-upload.de/19.06.15/bkqohvil2uao.jpg
 If the pedestrian starts walking around now, the sprites are always around her head, no matter where the head is displayed on the screen.  
 This function also effects the drawing of texts and other UI-elements.  
 The effect can be reset by calling GRAPHICS::CLEAR_DRAW_ORIGIN().  
+
+There seems to be a limit to how many different screen positions we can grab within one frame. Calling this more then 20 times in a loop returns 0,0.
 ```
 
 ## Parameters


### PR DESCRIPTION
This function returns x=0, y=0 if called too many times within a loop. 
I've tested getting a 3D position via WORLD3D_TO_SCREEN2D and it worked.
Using set_draw_origin instead, it returned 0,0 for indexes above 20.
