### PR TITLE
Update CreateCheckpoint.md

### DIFF
--- a/GRAPHICS/CreateCheckpoint.md
+++ b/GRAPHICS/CreateCheckpoint.md
@@ -15,7 +15,7 @@ Parameters:
 * type - The type of checkpoint to create. See below for a list of checkpoint types.  
 * pos1 - The position of the checkpoint.  
 * pos2 - The position of the next checkpoint to point to.  
-* diameter - The diameter of the checkpoint. This was previously incorrectly documented as radius.
+* diameter - The diameter of the checkpoint.
 * color - The color of the checkpoint.  
 * reserved - Special parameter, see below for details. Usually set to 0 in the scripts.  
 Checkpoint types (prior to game build 2189):  

--- a/GRAPHICS/CreateCheckpoint.md
+++ b/GRAPHICS/CreateCheckpoint.md
@@ -5,17 +5,17 @@ ns: GRAPHICS
 
 ```c
 // 0x0134F0835AB6BFCB 0xF541B690
-int CREATE_CHECKPOINT(int type, float posX1, float posY1, float posZ1, float posX2, float posY2, float posZ2, float radius, int red, int green, int blue, int alpha, int reserved);
+int CREATE_CHECKPOINT(int type, float posX1, float posY1, float posZ1, float posX2, float posY2, float posZ2, float diameter, int red, int green, int blue, int alpha, int reserved);
 ```
 
 ```
 Creates a checkpoint. Returns the handle of the checkpoint.  
-20/03/17 : Attention, checkpoints are already handled by the game itself, so you must not loop it like markers.  
+20/03/17 : Attention, checkpoints are already handled by the game itself, so you must not loop it like markers.
 Parameters:  
 * type - The type of checkpoint to create. See below for a list of checkpoint types.  
 * pos1 - The position of the checkpoint.  
 * pos2 - The position of the next checkpoint to point to.  
-* radius - The radius of the checkpoint.  
+* diameter - The diameter of the checkpoint. This was previously incorrectly documented as radius.
 * color - The color of the checkpoint.  
 * reserved - Special parameter, see below for details. Usually set to 0 in the scripts.  
 Checkpoint types (prior to game build 2189):  
@@ -55,7 +55,7 @@ If using type 42-44, reserved sets number / number and shape to display
 * **posX2**: 
 * **posY2**: 
 * **posZ2**: 
-* **radius**: 
+* **diameter**: 
 * **red**: 
 * **green**: 
 * **blue**: 


### PR DESCRIPTION
CreateCheckpoint uses diameter instead of radius. Verified by comparing checkpoints to blips and math.

Here's the code I used to verify.

	var pos = Game.PlayerPed.Position; var radius = 10f;
	API.CreateCheckpoint(45, pos.X, pos.Y, pos.Z, 0, 0, 0, radius, 225, 0, 0, 80, 0); //red
	API.CreateCheckpoint(45, pos.X, pos.Y, pos.Z, 0, 0, 0, radius * 2, 0, 225, 0, 80, 0); //green
	API.AddBlipForRadius(pos.X, pos.Y, pos.Z, radius);
	Game.PlayerPed.Position = pos + new Vector3(0, radius, 0);


In the end, the player and the white blip were aligned with the green checkpoint, where the "radius" variable is doubled.

![image](https://user-images.githubusercontent.com/36640936/126765730-e6118810-343f-41a3-8b86-23a045cb069d.png)



