### PR TITLE
Update SetGameplayPedHint.md p5, p6, p7 found

### DIFF
--- a/CAM/SetGameplayPedHint.md
+++ b/CAM/SetGameplayPedHint.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0x2B486269ACD548D3 0x7C27343E
-void SET_GAMEPLAY_PED_HINT(Ped p0, float x1, float y1, float z1, BOOL p4, Any duration, Any blendOutDuration, Any blendInDuration);
+void SET_GAMEPLAY_PED_HINT(Ped p0, float x1, float y1, float z1, BOOL p4, int duration, int blendOutDuration, int blendInDuration);
 ```
 
 
@@ -15,7 +15,7 @@ void SET_GAMEPLAY_PED_HINT(Ped p0, float x1, float y1, float z1, BOOL p4, Any du
 * **y1**: 
 * **z1**: 
 * **p4**: 
-* **p5**: 
-* **p6**: 
-* **p7**: 
+* **duration**: 
+* **blendOutDuration**: 
+* **blendInDuration**: 
 

--- a/CAM/SetGameplayPedHint.md
+++ b/CAM/SetGameplayPedHint.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0x2B486269ACD548D3 0x7C27343E
-void SET_GAMEPLAY_PED_HINT(Ped p0, float x1, float y1, float z1, BOOL p4, Any p5, Any p6, Any p7);
+void SET_GAMEPLAY_PED_HINT(Ped p0, float x1, float y1, float z1, BOOL p4, Any duration, Any blendOutDuration, Any blendInDuration);
 ```
 
 


### PR DESCRIPTION
p5: duration -> Time in ms to let the camera pointed at p0.
p6: blendOutDuration -> Time in ms to point the camera at p0.
p7: blendInDuration -> Time in ms to point the camera away from p0.

(Tests where made when p4 was true)
Hints taken by SET_GAMEPLAY_COORD_HINT.
Tested in GTA.