### PR TITLE
Update NetworkConcealPlayer.md

### DIFF
--- a/NETWORK/NetworkConcealPlayer.md
+++ b/NETWORK/NetworkConcealPlayer.md
@@ -8,7 +8,10 @@ ns: NETWORK
 void NETWORK_CONCEAL_PLAYER(Player player, BOOL toggle, BOOL p2);
 ```
 
-This is what R* uses to hide players in MP interiors.
+On all client(s), that are not present in the instance; you hide the player with NetworkConcealPlayer
+On the client(s), that are present in the instance; you hide the players who are not in the instance with NetworkConcealPlayer.
+
+This would conceal the player(s) in an unspecified location for each client, so any entity actions outside of an instance would not intervene with the instance that a given player would be in.
 
 ## Parameters
 * **player**: 


### PR DESCRIPTION
I've documented the NetworkConcealPlayer properly.

> This is what R* uses to hide players in MP interiors.

Did not give enough information for me to further develop my resource, where I had to research a ton, to come to the conclusion of what I've described in the PR.

There's not really a small code that would validate my change to a documentation review.