### PR TITLE
Added p8 (transition speed) and p11 (rotationOrder) to SetCamParams.md

### DIFF
--- a/CAM/SetCamParams.md
+++ b/CAM/SetCamParams.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0xBFD8727AEA3CCEBA 0x2167CEBF
-void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float fieldOfView, Any p8, int p9, int p10, int p11);
+void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float fieldOfView, int transitionSpeed, int p9, int p10, int p11);
 ```
 
 
@@ -18,8 +18,17 @@ void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, flo
 * **rotY**: 
 * **rotZ**: 
 * **fieldOfView**: 
-* **p8**: 
+* **transitionSpeed**: the time it takes for the camera to transition to new param values
 * **p9**: 
 * **p10**: 
 * **p11**: 
 
+### Example usage of transition speed in GTA:
+
+```c
+// finale_heist2a.c
+// transitions camera of heli view from left to right as seen in the following clip: https://youtu.be/XiEQHvfrc98?t=1141
+// (which takes 9100ms to complete)
+cam::set_cam_params(iLocal_2514, -1659.574f, -707.8544f, 29.23778f, -7.422939f, 0.059666f, -117.3886f, 43.0557f, 0, 1, 1, 2);
+cam::set_cam_params(iLocal_2514, -1660.919f, -710.7487f, 28.88381f, -7.50235f, 0.059666f, -111.7328f, 43.0557f, 9100, 0, 0, 2);
+```

--- a/CAM/SetCamParams.md
+++ b/CAM/SetCamParams.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0xBFD8727AEA3CCEBA 0x2167CEBF
-void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float fieldOfView, int transitionSpeed, int p9, int p10, int p11);
+void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float fieldOfView, int transitionSpeed, int p9, int p10, int rotationOrder);
 ```
 
 
@@ -18,10 +18,10 @@ void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, flo
 * **rotY**: 
 * **rotZ**: 
 * **fieldOfView**: 
-* **transitionSpeed**: the time it takes for the camera to transition to new param values
+* **transitionSpeed**: The time it takes for the camera to transition to new param values
 * **p9**: 
 * **p10**: 
-* **p11**: 
+* **rotationOrder**: The order of rotation values (`0`-`5`)
 
 ### Example usage of transition speed in GTA:
 
@@ -32,3 +32,14 @@ void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, flo
 cam::set_cam_params(iLocal_2514, -1659.574f, -707.8544f, 29.23778f, -7.422939f, 0.059666f, -117.3886f, 43.0557f, 0, 1, 1, 2);
 cam::set_cam_params(iLocal_2514, -1660.919f, -710.7487f, 28.88381f, -7.50235f, 0.059666f, -111.7328f, 43.0557f, 9100, 0, 0, 2);
 ```
+
+### Rotation Orders
+
+These rotation orders were shamelessly copied from the `GetEntityRotation` documentation. Thanks to @gottfriedleibniz for figuring out!
+
+* **0**: ZYX - Rotate around the z-axis, then the y-axis and finally the x-axis.
+* **1**: YZX - Rotate around the y-axis, then the z-axis and finally the x-axis.
+* **2**: ZXY - Rotate around the z-axis, then the x-axis and finally the y-axis.
+* **3**: XZY - Rotate around the x-axis, then the z-axis and finally the y-axis.
+* **4**: YXZ - Rotate around the y-axis, then the x-axis and finally the z-axis.
+* **5**: XYZ - Rotate around the x-axis, then the y-axis and finally the z-axis.

--- a/CAM/SetCamParams.md
+++ b/CAM/SetCamParams.md
@@ -48,31 +48,49 @@ These rotation orders were shamelessly copied from the `GET_ENTITY_ROTATION` doc
 ### Examples
 
 ```lua
-  local cam = CREATE_CAM_WITH_PARAMS(
-    'DEFAULT_SCRIPTED_CAMERA',
-    -1659.574, -707.8544, 29.23778,
-    0,0,0,
-    43.0557,
-    false,
-    2
-  )
-  SetCamActive(cam, true)
-  RenderScriptCams(true, false, 3000, true, false, false)
-  SetCamParams(cam, -1659.574, -707.8544, 29.23778, 0, 0, 0, 43.0557, 0,    1, 1, 2);
-  SetCamParams(cam, -1660.919, -710.7487, 28.88381, 0,45,45, 43.0557, 2100, 0, 0, 2);
+-- This is recreating the above mentioned heli transition from finale_heist2a.c
+  local cam = CreateCameraWithParams(
+  'DEFAULT_SCRIPTED_CAMERA',
+  -1659.574, -707.8544, 29.23778,
+  -7.422939, 0.059666, -117.3886,
+  43.0557,
+  false,
+  2
+)
+SetCamActive(cam, true)
+RenderScriptCams(true, false, 3000, true, false, false)
+SetCamParams(
+  cam,
+  -1660.919, -710.7487, 28.88381,
+  -7.50235, 0.059666, -111.7328,
+  43.0557,
+  9100,
+  0,
+  0,
+  2
+);
 ```
 
 ```js
-  const cam = CreateCameraWithParams(
-    'DEFAULT_SCRIPTED_CAMERA',
-    -1659.574, -707.8544, 29.23778,
-    0,0,0,
-    43.0557,
-    false,
-    2
-  )
-  SetCamActive(cam, true)
-  RenderScriptCams(true, false, 3000, true, false, false)
-  SetCamParams(cam, -1659.574, -707.8544, 29.23778, 0, 0, 0, 43.0557, 0,    1, 1, 2);
-  SetCamParams(cam, -1660.919, -710.7487, 28.88381, 0,45,45, 43.0557, 2100, 0, 0, 2);
+// This is recreating the above mentioned heli transition from finale_heist2a.c
+let cam = CreateCameraWithParams(
+  'DEFAULT_SCRIPTED_CAMERA',
+  -1659.574, -707.8544, 29.23778,
+  -7.422939, 0.059666, -117.3886,
+  43.0557,
+  false,
+  2
+)
+SetCamActive(cam, true)
+RenderScriptCams(true, false, 3000, true, false, false)
+SetCamParams(
+  cam,
+  -1660.919, -710.7487, 28.88381,
+  -7.50235, 0.059666, -111.7328,
+  43.0557,
+  9100,
+  0,
+  0,
+  2
+);
 ```

--- a/CAM/SetCamParams.md
+++ b/CAM/SetCamParams.md
@@ -10,6 +10,7 @@ void SET_CAM_PARAMS(Cam cam, float posX, float posY, float posZ, float rotX, flo
 
 
 ## Parameters
+
 * **cam**: 
 * **posX**: 
 * **posY**: 
@@ -35,7 +36,7 @@ cam::set_cam_params(iLocal_2514, -1660.919f, -710.7487f, 28.88381f, -7.50235f, 0
 
 ### Rotation Orders
 
-These rotation orders were shamelessly copied from the `GetEntityRotation` documentation. Thanks to @gottfriedleibniz for figuring out!
+These rotation orders were shamelessly copied from the `GET_ENTITY_ROTATION` documentation. Thanks to @gottfriedleibniz for figuring out!
 
 * **0**: ZYX - Rotate around the z-axis, then the y-axis and finally the x-axis.
 * **1**: YZX - Rotate around the y-axis, then the z-axis and finally the x-axis.
@@ -43,3 +44,35 @@ These rotation orders were shamelessly copied from the `GetEntityRotation` docum
 * **3**: XZY - Rotate around the x-axis, then the z-axis and finally the y-axis.
 * **4**: YXZ - Rotate around the y-axis, then the x-axis and finally the z-axis.
 * **5**: XYZ - Rotate around the x-axis, then the y-axis and finally the z-axis.
+
+### Examples
+
+```lua
+  local cam = CREATE_CAM_WITH_PARAMS(
+    'DEFAULT_SCRIPTED_CAMERA',
+    -1659.574, -707.8544, 29.23778,
+    0,0,0,
+    43.0557,
+    false,
+    2
+  )
+  SetCamActive(cam, true)
+  RenderScriptCams(true, false, 3000, true, false, false)
+  SetCamParams(cam, -1659.574, -707.8544, 29.23778, 0, 0, 0, 43.0557, 0,    1, 1, 2);
+  SetCamParams(cam, -1660.919, -710.7487, 28.88381, 0,45,45, 43.0557, 2100, 0, 0, 2);
+```
+
+```js
+  const cam = CreateCameraWithParams(
+    'DEFAULT_SCRIPTED_CAMERA',
+    -1659.574, -707.8544, 29.23778,
+    0,0,0,
+    43.0557,
+    false,
+    2
+  )
+  SetCamActive(cam, true)
+  RenderScriptCams(true, false, 3000, true, false, false)
+  SetCamParams(cam, -1659.574, -707.8544, 29.23778, 0, 0, 0, 43.0557, 0,    1, 1, 2);
+  SetCamParams(cam, -1660.919, -710.7487, 28.88381, 0,45,45, 43.0557, 2100, 0, 0, 2);
+```


### PR DESCRIPTION
Before you submit this PR, please make sure:

- [X] You have read the contribution guidelines
- [X] You include an example that validates your change
  - Included example from decompiled scripts of vanilla GTA heist
- [X] Your English is grammatically correct

---

This PR includes 2 new parameters for the SET_CAM_PARAMS native.

p8: `transitionSpeed`
p11: `rotationOrder`

Documentation for `rotationOrder` was copied from `GET_ENTITY_ROTATION` (Commit 0fb8e72e4b71ff01eaa1137c3854fff9b937b58c) 