### PR TITLE
Update TaskLeaveVehicle.md

### DIFF
--- a/TASK/TaskLeaveVehicle.md
+++ b/TASK/TaskLeaveVehicle.md
@@ -12,7 +12,7 @@ void TASK_LEAVE_VEHICLE(Ped ped, Vehicle vehicle, int flags);
 Flags from decompiled scripts:  
 0 = normal exit and closes door.  
 1 = normal exit and closes door.  
-16 = teleports outside, door kept closed.  
+16 = teleports outside, door kept closed.  (This flag does not seem to work for the front seats in buses, NPCs continue to exit normally)
 64 = normal exit and closes door, maybe a bit slower animation than 0.  
 256 = normal exit but does not close the door.  
 4160 = ped is throwing himself out, even when the vehicle is still.  


### PR DESCRIPTION
Flag 16 for `TaskLeaveVehicle` has no effect if NPC is sitting at the front of a bus, NPCs continue to exit normally without teleporting.