### PR TITLE
Update SetParticleFxNonLoopedColour.md

### DIFF
--- a/GRAPHICS/SetParticleFxNonLoopedColour.md
+++ b/GRAPHICS/SetParticleFxNonLoopedColour.md
@@ -8,10 +8,11 @@ ns: GRAPHICS
 void SET_PARTICLE_FX_NON_LOOPED_COLOUR(float r, float g, float b);
 ```
 
-only works on some fx's, not networked
+Changes the colour of the particle effect that will be drawn next. The particle can be networked or non-networked, but it must be non-looped for this native to work.
+
+The colour parameters accept RGB values on a scale from 0.0 to 1.0, therefore RGB values that follow the standard 0-255 scale can be easily used dividing said value by 255.
 
 ## Parameters
-* **r**: 
-* **g**: 
-* **b**: 
-
+* **r**: The red component of the particle's colour, on a scale from 0.0 to 1.0.
+* **g**: The green component of the particle's colour, on a scale from 0.0 to 1.0.
+* **b**: The blue component of the particle's colour, on a scale from 0.0 to 1.0.


### PR DESCRIPTION
The current description is in my opinion, misleading. People might think the colour parameters accept RGB values on a scale from 0 to 255 (at least, I did), while that isn't the case, as the scale goes from 0 to 1. Also it says 'not networked', but I've tested this native with another player in a server using Onesync Infinity and applied it to a networked particle effect drawing on the local player ped, and I could see the particle drawing on the other player's ped and changing colour just fine.