### PR TITLE
Update ClearEntityLastDamageEntity.md

### DIFF
--- a/ENTITY/ClearEntityLastDamageEntity.md
+++ b/ENTITY/ClearEntityLastDamageEntity.md
@@ -8,7 +8,9 @@ ns: ENTITY
 cs_type(Any) void CLEAR_ENTITY_LAST_DAMAGE_ENTITY(Entity entity);
 ```
 
+This native **could affect** the arguments of the `CEventNetworkEntityDamage` game event, by clearing the damaging entity before the event is fired.
+
 ## Parameters
-* **entity**: 
+* **entity**: The entity to clear the last damaging entity from.
 
 ## Return value


### PR DESCRIPTION
The commit's purpose is to make users know this native could conflict with the "CEventNetworkEntityDamage" game event.
Also, name the 'entity' parameter while I'm at it.
