### PR TITLE
External link was broken

### DIFF
--- a/PED/SetPedPropIndex.md
+++ b/PED/SetPedPropIndex.md
@@ -21,7 +21,7 @@ This native is used to set prop variation on a ped. Components, drawables and te
 [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47)  
 [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](#_0xA6E7F1CEB523E171)  
 
-[List of component/props ID](gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
+[List of component/props ID](https://gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
 
 ## Parameters
 * **ped**: The ped handle.


### PR DESCRIPTION
There was a missing " https:// " at start of URL, so link was broken for user.

ref: https://docs.fivem.net/natives/?_0x93376B65A266EB5F

no changes in code, only for online docs
