### PR TITLE
feat(natives): Add BF_FleesFromInvincibleOpponents

### DIFF
--- a/PED/SetPedCombatAttributes.md
+++ b/PED/SetPedCombatAttributes.md
@@ -8,9 +8,10 @@ ns: PED
 void SET_PED_COMBAT_ATTRIBUTES(Ped ped, int attributeIndex, BOOL enabled);
 ```
 
+
+These combat attributes seem to be the same as the BehaviourFlags from combatbehaviour.meta.
+So far, these are the equivalents found:
 ```
-These combat attributes seem to be the same as the BehaviourFlags from combatbehaviour.meta.  
-So far, these are the equivalents found:  
 enum CombatAttributes  
 {
 	BF_CanUseCover = 0,
@@ -25,12 +26,12 @@ enum CombatAttributes
         BF_FreezeMovement = 292,  
         BF_PlayerCanUseFiringWeapons = 1424  
 };
+```
 8 = ?  
 9 = ?  
 13 = ?  
 14 ?  
 Research thread: gtaforums.com/topic/833391-researchguide-combat-behaviour-flags/  
-```
 
 ## Parameters
 * **ped**: 

--- a/PED/SetPedCombatAttributes.md
+++ b/PED/SetPedCombatAttributes.md
@@ -12,18 +12,19 @@ void SET_PED_COMBAT_ATTRIBUTES(Ped ped, int attributeIndex, BOOL enabled);
 These combat attributes seem to be the same as the BehaviourFlags from combatbehaviour.meta.  
 So far, these are the equivalents found:  
 enum CombatAttributes  
-{  
-	BF_CanUseCover = 0,  
-	BF_CanUseVehicles = 1,  
-	BF_CanDoDrivebys = 2,  
-	BF_CanLeaveVehicle = 3,  
-	BF_CanFightArmedPedsWhenNotArmed = 5,  
-	BF_CanTauntInVehicle = 20,  
-	BF_AlwaysFight = 46,  
-	BF_IgnoreTrafficWhenDriving = 52,  
+{
+	BF_CanUseCover = 0,
+	BF_CanUseVehicles = 1,
+	BF_CanDoDrivebys = 2,
+	BF_CanLeaveVehicle = 3,
+	BF_CanFightArmedPedsWhenNotArmed = 5,
+	BF_CanTauntInVehicle = 20,
+	BF_AlwaysFight = 46,
+	BF_IgnoreTrafficWhenDriving = 52,
+	BF_FleesFromInvincibleOpponents = 63,
         BF_FreezeMovement = 292,  
         BF_PlayerCanUseFiringWeapons = 1424  
-};  
+};
 8 = ?  
 9 = ?  
 13 = ?  


### PR DESCRIPTION
BF_FleesFromInvincibleOpponenets is attributeIndex 63.

Figured out by testing with a panther, which has this flag, it will flee when set to true and attack when set to false.
