### PR TITLE
fix: update OpenPatrolRoute description

### DIFF
--- a/TASK/OpenPatrolRoute.md
+++ b/TASK/OpenPatrolRoute.md
@@ -9,6 +9,8 @@ void OPEN_PATROL_ROUTE(char* patrolRoute);
 ```
 
 ```
+The patrol route name must starts with "miss_" to be properly created. 
+
  patrolRoutes found in the b617d scripts:
  "miss_Ass0",
  "miss_Ass1",


### PR DESCRIPTION
The native checks if the patrol route name starts with miss_ before registering/creating it