### PR TITLE
Update some head blend related natives

### DIFF
--- a/PED/SetPedFaceFeature.md
+++ b/PED/SetPedFaceFeature.md
@@ -36,8 +36,11 @@ Chimp_Hole
 Neck_Thikness
 ```
 
+## Important
+You may need to call [`SetPedHeadBlendData`](#0x9414E18B9434C2FE) prior to calling this native in order for it to work.
+
 ## Parameters
-* **ped**: 
-* **index**: 
-* **scale**: 
+* **ped**: The ped entity
+* **index**: An integer ranging from 0 to 19
+* **scale**: A float ranging from -1.0 to 1.0
 

--- a/PED/SetPedHeadBlendData.md
+++ b/PED/SetPedHeadBlendData.md
@@ -8,29 +8,40 @@ ns: PED
 void SET_PED_HEAD_BLEND_DATA(Ped ped, int shapeFirstID, int shapeSecondID, int shapeThirdID, int skinFirstID, int skinSecondID, int skinThirdID, float shapeMix, float skinMix, float thirdMix, BOOL isParent);
 ```
 
-```
-The "shape" parameters control the shape of the ped's face. The "skin" parameters control the skin tone. ShapeMix and skinMix control how much the first and second IDs contribute,(typically mother and father.) ThirdMix overrides the others in favor of the third IDs. IsParent is set for "children" of the player character's grandparents during old-gen character creation. It has unknown effect otherwise.  
-The IDs start at zero and go Male Non-DLC, Female Non-DLC, Male DLC, and Female DLC.  
-!!!Can someone add working example for this???  
-try this:  
+## C# (doesn't apply to FiveM)
+```c
 headBlendData headData;  
 _GET_PED_HEAD_BLEND_DATA(PLAYER_PED_ID(), &headData);  
-SET_PED_HEAD_BLEND_DATA(PLAYER_PED_ID(), headData.shapeFirst, headData.shapeSecond, headData.shapeThird, headData.skinFirst, headData.skinSecond  
-	, headData.skinThird, headData.shapeMix, headData.skinMix, headData.skinThird, 0);  
-For more info please refer to this topic.   
-gtaforums.com/topic/858970-all-gtao-face-ids-pedset-ped-head-blend-data-explained  
+SET_PED_HEAD_BLEND_DATA(PLAYER_PED_ID(), headData.shapeFirst, headData.shapeSecond, headData.shapeThird, headData.skinFirst, headData.skinSecond, headData.skinThird, headData.shapeMix, headData.skinMix, headData.skinThird, 0); 
 ```
 
-## Parameters
-* **ped**: 
-* **shapeFirstID**: 
-* **shapeSecondID**: 
-* **shapeThirdID**: 
-* **skinFirstID**: 
-* **skinSecondID**: 
-* **skinThirdID**: 
-* **shapeMix**: 
-* **skinMix**: 
-* **thirdMix**: 
-* **isParent**: 
+For more info please refer to [this](https://gtaforums.com/topic/858970-all-gtao-face-ids-pedset-ped-head-blend-data-explained) topic.
 
+## Lua
+```lua
+-- Unfortunately, there's no clear way of getting the head blend data in lua out of the box, but there are wrappers:
+-- https://forum.cfx.re/t/small-c-export-event-wrapper-for-getpedheadblenddata/214611
+SetPedHeadBlendData(PlayerPedId(), 0, 0, 0, 0, 0, 0, 0, 0, 0, false)
+```
+
+## Other information
+IDs start at zero and go Male Non-DLC, Female Non-DLC, Male DLC, and Female DLC.</br>
+
+This native function is often called prior to calling natives such as:
+- [`SetPedHairColor`](#0xBB43F090)
+- [`SetPedHeadOverlayColor`](#0x78935A27)
+- [`SetPedHeadOverlay`](#0xD28DBA90)
+- [`SetPedFaceFeature`](#0x6C8D4458)
+
+## Parameters
+* **ped**: The ped entity
+* **shapeFirstID**: Controls the shape of the first ped's face
+* **shapeSecondID**: Controls the shape of the second ped's face
+* **shapeThirdID**: Controls the shape of the third ped's face
+* **skinFirstID**: Controls the first id's skin tone
+* **skinSecondID**: Controls the second id's skin tone
+* **skinThirdID**: Controls the third id's skin tone
+* **shapeMix**: 0.0 - 1.0 Of whose characteristics to take Mother -> Father (shapeFirstID and shapeSecondID)
+* **skinMix**: 0.0 - 1.0 Of whose characteristics to take Mother -> Father (skinFirstID and skinSecondID)
+* **thirdMix**: Overrides the others in favor of the third IDs. 
+* **isParent**: IsParent is set for "children" of the player character's grandparents during old-gen character creation. It has unknown effect otherwise.

--- a/PED/SetPedHeadOverlay.md
+++ b/PED/SetPedHeadOverlay.md
@@ -26,9 +26,12 @@ overlayID       Part                  Index, to disable
 12              Add Body Blemishes    0 - 1, 255  
 ```
 
+## Important
+You may need to call [`SetPedHeadBlendData`](#0x9414E18B9434C2FE) prior to calling this native in order for it to work.
+
 ## Parameters
-* **ped**: 
-* **overlayID**: 
-* **index**: 
-* **opacity**: 
+* **ped**: The ped entity
+* **overlayID**: The overlay id displayed up above.
+* **index**: An integer representing the index (from 0 to `_GET_NUM_OVERLAY_VALUES(overlayID)-1`)
+* **opacity**: A float ranging from 0.0 to 1.0
 

--- a/PED/SetPedHeadOverlayColor.md
+++ b/PED/SetPedHeadOverlayColor.md
@@ -9,15 +9,17 @@ void _SET_PED_HEAD_OVERLAY_COLOR(Ped ped, int overlayID, int colorType, int colo
 ```
 
 ```
-Used for freemode (online) characters.  
-ColorType is 1 for eyebrows, beards, and chest hair; 2 for blush and lipstick; and 0 otherwise, though not called in those cases.  
+Used for freemode (online) characters. 
 Called after SET_PED_HEAD_OVERLAY().  
 ```
 
+## Important
+You may need to call [`SetPedHeadBlendData`](#0x9414E18B9434C2FE) prior to calling this native in order for it to work.
+
 ## Parameters
-* **ped**: 
-* **overlayID**: 
-* **colorType**: 
-* **colorID**: 
-* **secondColorID**: 
+* **ped**: The ped entity
+* **overlayID**: An integer representing the overlay id
+* **colorType**: 1 for eyebrows, beards, and chest hair; 2 for blush and lipstick; and 0 otherwise, though not called in those cases. 
+* **colorID**: An integer representing the primary color id
+* **secondColorID**: An integer representing the secondary color id
 


### PR DESCRIPTION
Also let the users know they should call `SetPedHeadBlendData` prior to calling certain natives since I noticed someone on Discord was claiming a native named `SetPedFaceFeature` wasn't working until they called `SetPedHeadBlendData` prior to it. Turns out the game actually has a method that blocks the call if a specific flag in `modelInfo` isn't set for that ped. 

```
bool __fastcall checkPedCanChangeHairColor(CPed *pPed)
{
  bool result; // al

  if ( (BYTE6(pPed->modelInfo[3].qw58) & 2) != 0 )
    result = fwExtensibleBase::GetExtension(&pPed->extensions, EXTENSION_CPEDHEADBLENDDATA) != 0i64;
  else
    result = 0;
  return result;
}
```
