### PR TITLE
Updated _GET_SCALEFORM_MOVIE_CURSOR_SELECTION.

### DIFF
--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -11,6 +11,7 @@ BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) bo
   
 ## Parameters
 * **scaleformHandle**: Handle of the scaleform
+* **received**: Returns a boolean indicating if the data was received successfully.
 * **selectionType**: The type of MouseEvent specified above.
 * **context**: Context of the slot the mouse is hovering on.
 * **slotIndex**: Index of the slot the mouse is hovering on.

--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -8,16 +8,6 @@ aliases: ["0x632B2940C67F4EA9"]
 // 0x632B2940C67F4EA9
 BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) bool* received, cs_type(Any*) int* selectionType, cs_type(Any*) int* context, int* slotIndex);
 ```
-  
-## Parameters
-* **scaleformHandle**: Handle of the scaleform
-* **received**: Returns a boolean indicating if the data was received successfully.
-* **selectionType**: The type of MouseEvent specified above.
-* **context**: Context of the slot the mouse is hovering on.
-* **slotIndex**: Index of the slot the mouse is hovering on.
-
-## Return value
-* **retVal** Returns true if MOUSE_EVENT callback from Scaleforms has been called.
 
 Gets mouse selection data from scaleforms with mouse support. Must be checked every frame.
 Returns item index if using the COLOUR_SWITCHER_02 scaleform.
@@ -60,4 +50,15 @@ if (success)
     itemId = _itemId.GetResult<int>();
     context = _context.GetResult<int>();
 }
+
+  
+## Parameters
+* **scaleformHandle**: Handle of the scaleform
+* **received**: Returns a boolean indicating if the data was received successfully.
+* **selectionType**: The type of MouseEvent specified above.
+* **context**: Context of the slot the mouse is hovering on.
+* **slotIndex**: Index of the slot the mouse is hovering on.
+
+## Return value
+* **retVal** Returns true if MOUSE_EVENT callback from Scaleforms has been called.
 ```

--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -6,9 +6,19 @@ aliases: ["0x632B2940C67F4EA9"]
  
 ```c
 // 0x632B2940C67F4EA9
-BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) int* selectionType, cs_type(Any*) int* slotIndex, Any* p3);
+BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) bool* received, cs_type(Any*) int* selectionType, cs_type(Any*) int* context, int* slotIndex);
 ```
- 
+  
+## Parameters
+* **scaleformHandle**: Handle of the scaleform
+* **selectionType**: The type of MouseEvent specified above.
+* **context**: Context of the slot the mouse is hovering on.
+* **slotIndex**: Index of the slot the mouse is hovering on.
+
+ Returns item index if using the COLOUR_SWITCHER_02 scaleform.
+## Return value
+* **retVal** Returns true if MOUSE_EVENT callback from Scaleforms has been called.
+
 Gets mouse selection data from scaleforms with mouse support. Must be checked every frame.
 Selection types, found in MOUSE_EVENTS.as:
 MOUSE_DRAG_OUT = 0;
@@ -31,37 +41,22 @@ Scaleforms that this works with:
 - SC_LEADERBOARD
 Probably works with other scaleforms, needs more research.
 In order to use this Native you MUST have controls 239, 240, 237, 238 enabled!
- 
-## Parameters
-* **scaleformHandle**: Handle of the scaleform
-* **selectionType**:  
-* **slotIndex**: Index of the slot the mouse is hovering on
-* **p3**: Returns the optional parameters specified in the MOUSE_EVENT api callback as specified in MouseBtn.as sendMouseEvent function.
+This native, due to its erroneous redundancy of the returned boolean value, doesn't work on C# unless you call Function class.
 
-Taken from MouseBtn.as:
- ```as
-	function sendMouseEvent(id)
-	{
-		var _loc4_ = [id, this._name]; // this is the array of parameters to be sent to the internal callback function and the MOUSE_EVT api callback back to the game.
-		var _loc3_ = this.optionalMouseArgs.length;
-		if (_loc3_ > 0)
-		{
-			var _loc2_ = 0;
-			while (_loc2_ < _loc3_)
-			{
-				_loc4_.push(this.optionalMouseArgs[_loc2_]);
-				_loc2_ = _loc2_ + 1;
-			}
-		}
-		if (this.isMouseEnabled)
-		{
-			if (this.callback)
-			{
-				this.callback.apply(this,[id, this, this.callbackArgs]); // internal scaleform callback
-			}
-			this.MOUSE_EVT.triggerEvent(_loc4_); // external api scaleform callback.
-		}
-	}
- ```
- Returns item index if using the COLOUR_SWITCHER_02 scaleform.
-## Return value
+## Examples
+```cs
+int eventType = 0;
+int itemId = 0;
+int context = 0;
+
+OutputArgument _eventType = new OutputArgument();
+OutputArgument _context = new OutputArgument();
+OutputArgument _itemId = new OutputArgument();
+bool success = Function.Call<bool>(Hash._GET_SCALEFORM_MOVIE_CURSOR_SELECTION, scaleform.Handle, _eventType, _context, _itemId);
+if (success)
+{
+    eventType = _eventType.GetResult<int>();
+    itemId = _itemId.GetResult<int>();
+    context = _context.GetResult<int>();
+}
+```

--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -6,10 +6,10 @@ aliases: ["0x632B2940C67F4EA9"]
  
 ```c
 // 0x632B2940C67F4EA9
-BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) bool* received, cs_type(Any*) int* selectionType, cs_type(Any*) int* slotIndex, int* p4);
+BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) int* selectionType, cs_type(Any*) int* slotIndex, Any* p3);
 ```
  
-Gets mouse selection data from scaleforms with mouse support. Must be checked every frame
+Gets mouse selection data from scaleforms with mouse support. Must be checked every frame.
 Selection types, found in MOUSE_EVENTS.as:
 MOUSE_DRAG_OUT = 0;
 MOUSE_DRAG_OVER = 1;
@@ -33,9 +33,34 @@ Probably works with other scaleforms, needs more research.
  
 ## Parameters
 * **scaleformHandle**: Handle of the scaleform
-* **received**: Returns a boolean indicating if the data was received successfully
 * **selectionType**:  
 * **slotIndex**: Index of the slot the mouse is hovering on
-* **p4**: Purpose unknown, always returns -1 or 0. Returns item index if using the COLOUR_SWITCHER_02 scaleform
- 
+* **p3**: Returns the optional parameters specified in the MOUSE_EVENT api callback as specified in MouseBtn.as sendMouseEvent function.
+
+Taken from MouseBtn.as:
+ ```as
+	function sendMouseEvent(id)
+	{
+		var _loc4_ = [id, this._name]; // this is the array of parameters to be sent to the internal callback function and the MOUSE_EVT api callback back to the game.
+		var _loc3_ = this.optionalMouseArgs.length;
+		if (_loc3_ > 0)
+		{
+			var _loc2_ = 0;
+			while (_loc2_ < _loc3_)
+			{
+				_loc4_.push(this.optionalMouseArgs[_loc2_]);
+				_loc2_ = _loc2_ + 1;
+			}
+		}
+		if (this.isMouseEnabled)
+		{
+			if (this.callback)
+			{
+				this.callback.apply(this,[id, this, this.callbackArgs]); // internal scaleform callback
+			}
+			this.MOUSE_EVT.triggerEvent(_loc4_); // external api scaleform callback.
+		}
+	}
+ ```
+ Returns item index if using the COLOUR_SWITCHER_02 scaleform.
 ## Return value

--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -30,6 +30,7 @@ Scaleforms that this works with:
 - MP_NEXT_JOB_SELECTION
 - SC_LEADERBOARD
 Probably works with other scaleforms, needs more research.
+In order to use this Native you MUST have controls 239, 240, 237, 238 enabled!
  
 ## Parameters
 * **scaleformHandle**: Handle of the scaleform

--- a/HUD/GetScaleformMovieCursorSelection.md
+++ b/HUD/GetScaleformMovieCursorSelection.md
@@ -16,11 +16,11 @@ BOOL _GET_SCALEFORM_MOVIE_CURSOR_SELECTION(int scaleformHandle, cs_type(Any*) bo
 * **context**: Context of the slot the mouse is hovering on.
 * **slotIndex**: Index of the slot the mouse is hovering on.
 
- Returns item index if using the COLOUR_SWITCHER_02 scaleform.
 ## Return value
 * **retVal** Returns true if MOUSE_EVENT callback from Scaleforms has been called.
 
 Gets mouse selection data from scaleforms with mouse support. Must be checked every frame.
+Returns item index if using the COLOUR_SWITCHER_02 scaleform.
 Selection types, found in MOUSE_EVENTS.as:
 MOUSE_DRAG_OUT = 0;
 MOUSE_DRAG_OVER = 1;


### PR DESCRIPTION
* In the scripts there's no evidence of 5 paramters as in each script using this native only 4 parameters are given.
  * for example in hairdo_shop_mp: `HUD::_0x632B2940C67F4EA9(uParam0->f_614, &iVar4, &iVar5, &uVar6)`
* Updated p3 description.