### PR TITLE
fix(SetPedComponentVariation): wrong link to component/props IDs

### DIFF
--- a/PED/SetPedComponentVariation.md
+++ b/PED/SetPedComponentVariation.md
@@ -28,7 +28,7 @@ This native is used to set component variation on a ped. Components, drawables a
 [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](#_0x27561561732A7842)  
 [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](#_0x8F7156A3142A6BAD)  
 
-[List of component/props ID](gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
+[List of component/props ID](https://gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
 
 ## Parameters
 * **ped**: The ped handle.


### PR DESCRIPTION
This link currently sends you to `https://docs.fivem.net/natives/gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html` on the native reference documentation, when it should send you to `https://gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html`, this PR fixes that.
