### PR TITLE
Replace blogspot link for ped component and prop ids with gamecode enumeration

### DIFF
--- a/HUD/GetBlipSprite.md
+++ b/HUD/GetBlipSprite.md
@@ -8,12 +8,9 @@ ns: HUD
 int GET_BLIP_SPRITE(Blip blip);
 ```
 
-```
-Blips Images + IDs:  
-gtaxscripting.blogspot.com/2016/05/gta-v-blips-id-and-image.html  
-```
+Gets the sprite id of the specified blip. Blip sprite ids and images can be found [here](https://docs.fivem.net/docs/game-references/blips/).
 
 ## Parameters
-* **blip**: 
+* **blip**: The blip handle.
 
 ## Return value

--- a/PED/ClearAllPedProps.md
+++ b/PED/ClearAllPedProps.md
@@ -8,11 +8,5 @@ ns: PED
 void CLEAR_ALL_PED_PROPS(Ped ped);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-
+* **ped**: The ped handle.

--- a/PED/ClearPedProp.md
+++ b/PED/ClearPedProp.md
@@ -8,12 +8,6 @@ ns: PED
 void CLEAR_PED_PROP(Ped ped, int propId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **propId**: 
-
+* **ped**: The ped handle.
+* **propId**: The prop id you want to clear from the ped. Refer to [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F).

--- a/PED/GetNumberOfPedDrawableVariations.md
+++ b/PED/GetNumberOfPedDrawableVariations.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS(Ped ped, int componentId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id you want to get the drawable variatons of. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80)
 
 ## Return value

--- a/PED/GetNumberOfPedPropDrawableVariations.md
+++ b/PED/GetNumberOfPedPropDrawableVariations.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS(Ped ped, int propId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **propId**: 
+* **ped**: The ped handle.
+* **propId**: The prop id you want to get the drawable variations of. Refer to [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F)
 
 ## Return value

--- a/PED/GetNumberOfPedPropTextureVariations.md
+++ b/PED/GetNumberOfPedPropTextureVariations.md
@@ -9,15 +9,12 @@ int GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS(Ped ped, int propId, int drawableI
 ```
 
 ```
-Need to check behavior when drawableId = -1  
-
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
+Need to check behavior when drawableId = -1
 ```
 
 ## Parameters
-* **ped**: 
-* **propId**: 
-* **drawableId**: 
+* **ped**: The ped handle.
+* **propId**: The prop id you want to get the texture variations of. Refer to [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F)
+* **drawableId**: The drawable id of the prop you want to get the texture variations of. Refer to [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47).
 
 ## Return value

--- a/PED/GetNumberOfPedTextureVariations.md
+++ b/PED/GetNumberOfPedTextureVariations.md
@@ -8,14 +8,9 @@ ns: PED
 int GET_NUMBER_OF_PED_TEXTURE_VARIATIONS(Ped ped, int componentId, int drawableId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
-* **drawableId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id you want to get the texture variations of. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
+* **drawableId**: The drawable id of the component you want to get the texture variations of. Refer to [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47).
 
 ## Return value

--- a/PED/GetPedPaletteVariation.md
+++ b/PED/GetPedPaletteVariation.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_PED_PALETTE_VARIATION(Ped ped, int componentId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id to get the palette variation from. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
 
 ## Return value

--- a/PED/GetPedPropIndex.md
+++ b/PED/GetPedPropIndex.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_PED_PROP_INDEX(Ped ped, int componentId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id to get the prop index from. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
 
 ## Return value

--- a/PED/GetPedPropTextureIndex.md
+++ b/PED/GetPedPropTextureIndex.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_PED_PROP_TEXTURE_INDEX(Ped ped, int componentId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id to get the prop texture index from. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
 
 ## Return value

--- a/PED/GetPedTextureVariation.md
+++ b/PED/GetPedTextureVariation.md
@@ -8,13 +8,8 @@ ns: PED
 int GET_PED_TEXTURE_VARIATION(Ped ped, int componentId);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-* **componentId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id to get the texture variation from. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
 
 ## Return value

--- a/PED/IsPedComponentVariationValid.md
+++ b/PED/IsPedComponentVariationValid.md
@@ -9,12 +9,11 @@ BOOL IS_PED_COMPONENT_VARIATION_VALID(Ped ped, int componentId, int drawableId, 
 ```
 
 Checks if the component variation is valid, this works great for randomizing components using loops.  
-List of component/props ID can be found in [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80)
 
 ## Parameters
-* **ped**: 
-* **componentId**: 
-* **drawableId**: 
-* **textureId**: 
+* **ped**: The ped handle.
+* **componentId**: The component id to check the variation of. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
+* **drawableId**: The drawable id to get the component variation of. Refer to [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47).
+* **textureId**: The texture id to get the component variation of. Refer to [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](#_0xA6E7F1CEB523E171).
 
 ## Return value

--- a/PED/IsPedComponentVariationValid.md
+++ b/PED/IsPedComponentVariationValid.md
@@ -8,11 +8,8 @@ ns: PED
 BOOL IS_PED_COMPONENT_VARIATION_VALID(Ped ped, int componentId, int drawableId, int textureId);
 ```
 
-```
 Checks if the component variation is valid, this works great for randomizing components using loops.  
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
+List of component/props ID can be found in [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80)
 
 ## Parameters
 * **ped**: 

--- a/PED/KnockOffPedProp.md
+++ b/PED/KnockOffPedProp.md
@@ -8,11 +8,6 @@ ns: PED
 void KNOCK_OFF_PED_PROP(Ped ped, BOOL p1, BOOL p2, BOOL p3, BOOL p4);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
 * **ped**: 
 * **p1**: 

--- a/PED/SetPedComponentVariation.md
+++ b/PED/SetPedComponentVariation.md
@@ -24,10 +24,6 @@ This native is used to set component variation on a ped. Components, drawables a
 **10**: Badge
 **11**: Torso 2
 
-### Related and useful natives
-[GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](#_0x27561561732A7842)  
-[GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](#_0x8F7156A3142A6BAD)  
-
 List of Component IDs
 ```c
 // Components
@@ -53,6 +49,6 @@ enum ePedVarComp
 ## Parameters
 * **ped**: The ped handle.
 * **componentId**: The component that you want to set.
-* **drawableId**: The drawable id that is going to be set.
-* **textureId**: The texture id of the drawable.
+* **drawableId**: The drawable id that is going to be set. Refer to [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](#_0x27561561732A7842).
+* **textureId**: The texture id of the drawable. Refer to [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](#_0x8F7156A3142A6BAD).
 * **paletteId**: 0 to 3.

--- a/PED/SetPedComponentVariation.md
+++ b/PED/SetPedComponentVariation.md
@@ -8,27 +8,67 @@ ns: PED
 void SET_PED_COMPONENT_VARIATION(Ped ped, int componentId, int drawableId, int textureId, int paletteId);
 ```
 
-This native is used to set component variation on a ped. Components, drawables and textures IDs are related to the ped model. 
+This native is used to set component variation on a ped. Components, drawables and textures IDs are related to the ped model.
 
 ### MP Freemode list of components
-**0**: Face  
-**1**: Mask  
-**2**: Hair  
-**3**: Torso  
-**4**: Leg  
-**5**: Parachute / bag  
-**6**: Shoes  
-**7**: Accessory  
-**8**: Undershirt  
-**9**: Kevlar  
-**10**: Badge  
-**11**: Torso 2  
+**0**: Face
+**1**: Mask
+**2**: Hair
+**3**: Torso
+**4**: Leg
+**5**: Parachute / bag
+**6**: Shoes
+**7**: Accessory
+**8**: Undershirt
+**9**: Kevlar
+**10**: Badge
+**11**: Torso 2
 
 ### Related and useful natives
 [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](#_0x27561561732A7842)  
 [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](#_0x8F7156A3142A6BAD)  
 
-[List of component/props ID](gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
+List of Component IDs and Prop IDs
+```C
+// Components
+enum ePedVarComp
+{
+    PV_COMP_INVALID = 0xFFFFFFFF,
+    PV_COMP_HEAD = 0, // "HEAD"
+    PV_COMP_BERD = 1, // "BEARD"
+    PV_COMP_HAIR = 2, // "HAIR"
+    PV_COMP_UPPR = 3, // "UPPER"
+    PV_COMP_LOWR = 4, // "LOWER"
+    PV_COMP_HAND = 5, // "HAND"
+    PV_COMP_FEET = 6, // "FEET"
+    PV_COMP_TEEF = 7, // "TEETH"
+    PV_COMP_ACCS = 8, // "ACCESSORIES"
+    PV_COMP_TASK = 9, // "TASK"
+    PV_COMP_DECL = 10, // "DECL"
+    PV_COMP_JBIB = 11, // "JBIB"
+    PV_COMP_MAX = 12,
+};
+
+
+// Props
+enum eAnchorPoints
+{
+    ANCHOR_HEAD = 0, // "p_head"
+    ANCHOR_EYES = 1, // "p_eyes"
+    ANCHOR_EARS = 2, // "p_ears"
+    ANCHOR_MOUTH = 3, // "p_mouth"
+    ANCHOR_LEFT_HAND = 4, // "p_lhand"
+    ANCHOR_RIGHT_HAND = 5, // "p_rhand"
+    ANCHOR_LEFT_WRIST = 6, // "p_lwrist"
+    ANCHOR_RIGHT_WRIST = 7, // "p_rwrist"
+    ANCHOR_HIP = 8, // "p_lhip"
+    ANCHOR_LEFT_FOOT = 9, // "p_lfoot"
+    ANCHOR_RIGHT_FOOT = 10, // "p_rfoot"
+    ANCHOR_PH_L_HAND = 11, // "ph_lhand"
+    ANCHOR_PH_R_HAND = 12, // "ph_rhand"
+    NUM_ANCHORS = 13,
+};
+```
 
 ## Parameters
 * **ped**: The ped handle.

--- a/PED/SetPedComponentVariation.md
+++ b/PED/SetPedComponentVariation.md
@@ -28,8 +28,8 @@ This native is used to set component variation on a ped. Components, drawables a
 [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](#_0x27561561732A7842)  
 [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](#_0x8F7156A3142A6BAD)  
 
-List of Component IDs and Prop IDs
-```C
+List of Component IDs
+```c
 // Components
 enum ePedVarComp
 {
@@ -47,26 +47,6 @@ enum ePedVarComp
     PV_COMP_DECL = 10, // "DECL"
     PV_COMP_JBIB = 11, // "JBIB"
     PV_COMP_MAX = 12,
-};
-
-
-// Props
-enum eAnchorPoints
-{
-    ANCHOR_HEAD = 0, // "p_head"
-    ANCHOR_EYES = 1, // "p_eyes"
-    ANCHOR_EARS = 2, // "p_ears"
-    ANCHOR_MOUTH = 3, // "p_mouth"
-    ANCHOR_LEFT_HAND = 4, // "p_lhand"
-    ANCHOR_RIGHT_HAND = 5, // "p_rhand"
-    ANCHOR_LEFT_WRIST = 6, // "p_lwrist"
-    ANCHOR_RIGHT_WRIST = 7, // "p_rwrist"
-    ANCHOR_HIP = 8, // "p_lhip"
-    ANCHOR_LEFT_FOOT = 9, // "p_lfoot"
-    ANCHOR_RIGHT_FOOT = 10, // "p_rfoot"
-    ANCHOR_PH_L_HAND = 11, // "ph_lhand"
-    ANCHOR_PH_R_HAND = 12, // "ph_rhand"
-    NUM_ANCHORS = 13,
 };
 ```
 

--- a/PED/SetPedHelmetPropIndex.md
+++ b/PED/SetPedHelmetPropIndex.md
@@ -9,15 +9,10 @@ void SET_PED_HELMET_PROP_INDEX(Ped ped, int propIndex);
 ```
 
 ```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
-```
 NativeDB Added Parameter 3: BOOL p2
 ```
 
 ## Parameters
-* **ped**: 
-* **propIndex**: 
+* **ped**: The ped handle.
+* **propIndex**: The prop index to set the helmet to. Refer to [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F).
 

--- a/PED/SetPedPreloadPropData.md
+++ b/PED/SetPedPreloadPropData.md
@@ -6,18 +6,13 @@ aliases: ["0x2B16A3BFF1FBCE49","_IS_PED_PROP_VALID"]
 
 ```c
 // 0x2B16A3BFF1FBCE49 0xC0E23671
-BOOL SET_PED_PRELOAD_PROP_DATA(Ped ped, int componentId, int drawableId, int TextureId);
-```
-
-```
-List of component/props ID
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html
+BOOL SET_PED_PRELOAD_PROP_DATA(Ped ped, int componentId, int drawableId, int textureId);
 ```
 
 ## Parameters
-* **ped**: 
-* **componentId**: 
-* **drawableId**: 
-* **TextureId**: 
+* **ped**: The ped handle.
+* **componentId**: The component that you want to set. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
+* **drawableId**: The drawable id that is going to be set. Refer to [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47).
+* **textureId**: The texture id of the drawable. Refer to [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](#_0xA6E7F1CEB523E171).
 
 ## Return value

--- a/PED/SetPedPropIndex.md
+++ b/PED/SetPedPropIndex.md
@@ -8,24 +8,40 @@ ns: PED
 void SET_PED_PROP_INDEX(Ped ped, int componentId, int drawableId, int textureId, BOOL attach);
 ```
 
-This native is used to set prop variation on a ped. Components, drawables and textures IDs are related to the ped model. 
+This native is used to set prop variation on a ped. Components, drawables and textures IDs are related to the ped model.
 
 ### MP Freemode list of props
-**0**: Hat  
-**1**: Glass  
-**2**: Ear  
-**6**: Watch  
-**7**: Bracelet  
+**0**: Hats
+**1**: Glasses
+**2**: Ears
+**6**: Watches
+**7**: Bracelets
 
-### Related and useful natives
-[GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47)  
-[GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](#_0xA6E7F1CEB523E171)  
-
-[List of component/props ID](https://gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html) of player_two with examples
+List of Prop IDs
+```c
+// Props
+enum eAnchorPoints
+{
+    ANCHOR_HEAD = 0, // "p_head"
+    ANCHOR_EYES = 1, // "p_eyes"
+    ANCHOR_EARS = 2, // "p_ears"
+    ANCHOR_MOUTH = 3, // "p_mouth"
+    ANCHOR_LEFT_HAND = 4, // "p_lhand"
+    ANCHOR_RIGHT_HAND = 5, // "p_rhand"
+    ANCHOR_LEFT_WRIST = 6, // "p_lwrist"
+    ANCHOR_RIGHT_WRIST = 7, // "p_rwrist"
+    ANCHOR_HIP = 8, // "p_lhip"
+    ANCHOR_LEFT_FOOT = 9, // "p_lfoot"
+    ANCHOR_RIGHT_FOOT = 10, // "p_rfoot"
+    ANCHOR_PH_L_HAND = 11, // "ph_lhand"
+    ANCHOR_PH_R_HAND = 12, // "ph_rhand"
+    NUM_ANCHORS = 13,
+};
+```
 
 ## Parameters
 * **ped**: The ped handle.
-* **componentId**: The component that you want to set.
-* **drawableId**: The drawable id that is going to be set.
-* **textureId**: The texture id of the drawable.
-* **attach**: Attached or not. 
+* **componentId**: The component that you want to set. Refer to [SET_PED_COMPONENT_VARIATION](#_0x262B14F48D29DE80).
+* **drawableId**: The drawable id that is going to be set. Refer to [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](#_0x5FAF9754E789FB47).
+* **textureId**: The texture id of the drawable. Refer to [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](#_0xA6E7F1CEB523E171).
+* **attach**: Attached or not.

--- a/PED/SetPedRandomComponentVariation.md
+++ b/PED/SetPedRandomComponentVariation.md
@@ -10,12 +10,8 @@ void SET_PED_RANDOM_COMPONENT_VARIATION(Ped ped, cs_type(BOOL) int p1);
 
 ```
 p1 is always 0 in R* scripts; and a quick disassembly seems to indicate that p1 is unused.  
-
-List of component/props ID:
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
 ```
 
 ## Parameters
 * **ped**: 
 * **p1**: 
-

--- a/PED/SetPedRandomProps.md
+++ b/PED/SetPedRandomProps.md
@@ -8,11 +8,5 @@ ns: PED
 void SET_PED_RANDOM_PROPS(Ped ped);
 ```
 
-```
-List of component/props ID  
-gtaxscripting.blogspot.com/2016/04/gta-v-peds-component-and-props.html  
-```
-
 ## Parameters
-* **ped**: 
-
+* **ped**: The ped handle.


### PR DESCRIPTION
This replaces the link of the component and prop IDs of SetPedComponentVariation with the gamecode enum @gottfriedleibniz provided me with in #764.
