### PR TITLE
Include language that informs native should be used per frame

### DIFF
--- a/PLAYER/DisablePlayerVehicleRewards.md
+++ b/PLAYER/DisablePlayerVehicleRewards.md
@@ -7,10 +7,9 @@ ns: PLAYER
 // 0xC142BE3BB9CE125F 0x8C6E611D
 void DISABLE_PLAYER_VEHICLE_REWARDS(Player player);
 ```
-```
+
 Disables vehicle rewards for the current frame.  
-```
 
 ## Parameters
-* **player**: 
+* **player**: The player to disable rewards
 

--- a/PLAYER/DisablePlayerVehicleRewards.md
+++ b/PLAYER/DisablePlayerVehicleRewards.md
@@ -7,7 +7,9 @@ ns: PLAYER
 // 0xC142BE3BB9CE125F 0x8C6E611D
 void DISABLE_PLAYER_VEHICLE_REWARDS(Player player);
 ```
-
+```
+Disables vehicle rewards for the current frame.  
+```
 
 ## Parameters
 * **player**: 


### PR DESCRIPTION
This native, unlike some others that are appended with "ThisFrame," does not have that luxury. This should help reduce forum topics complaining that the native does not work.
