### PR TITLE
Update SetPlayerResetFlagPreferRearSeats.md

### DIFF
--- a/PLAYER/SetPlayerResetFlagPreferRearSeats.md
+++ b/PLAYER/SetPlayerResetFlagPreferRearSeats.md
@@ -12,7 +12,8 @@ void SET_PLAYER_RESET_FLAG_PREFER_REAR_SEATS(Player player, int flags);
 example:  
 flags: 0-6  
 PLAYER::SET_PLAYER_RESET_FLAG_PREFER_REAR_SEATS(PLAYER::PLAYER_ID(), 6);  
-wouldnt the flag be the seatIndex?  
+
+This native appears to set the theme for the mobile phone in GTA singleplayer. So in no way does what the native name implies it would do.
 ```
 
 ## Parameters


### PR DESCRIPTION
This native is only used in the mobile phone scripts of GTA, and in these scripts there's a switch case on a global which contains phone settings.

This same global field is also passed to a scaleform method called "SET_THEME", and to a function which changes the object variation of the mobile phone object, as such I have concluded that this is probably something related to the theme settings of the mobile phone.

In game this native also appears to have no effect whatsoever, which would line up with it being related to the mobile phone.
