### PR TITLE
Fix type for N_0xc64a06d939f826f5 parameter 1

### DIFF
--- a/AUDIO/N_0xc64a06d939f826f5.md
+++ b/AUDIO/N_0xc64a06d939f826f5.md
@@ -5,7 +5,7 @@ ns: AUDIO
 
 ```c
 // 0xC64A06D939F826F5
-BOOL _0xC64A06D939F826F5(float* p0, Any* p1, int* p2);
+BOOL _0xC64A06D939F826F5(float* p0, cs_type(AnyPtr) float* p1, int* p2);
 ```
 
 ```


### PR DESCRIPTION
Restores the ability to execute this native, pointer argument safety improvements caused p1 to not get passed along and the game needs it to be a valid pointer.
This natives exists purely to retrieve existing values from an in-game struct, the correct type was discovered by looking at usage of this value within game code.

Example (lua):
`local success,fVar0,fVar1,iVar2 = N_0xc64a06d939f826f5()`
Attempting to run this snippet before adjusting the definition would result in a crash.