### PR TITLE
STOP_ANIM_TASK: add 4th parameter ('speed')

### DIFF
--- a/TASK/StopAnimTask.md
+++ b/TASK/StopAnimTask.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0x97FF36A1D40EA00A 0x2B520A57
-void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float p3);
+void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float speed);
 ```
 
 [Animations list](https://alexguirre.github.io/animations-list/)
@@ -14,5 +14,5 @@ void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float p3
 * **ped**: 
 * **animDictionary**: 
 * **animationName**: 
-* **p3**: 
+* **speed**: Exclusive between `0.0` and `2.0`, higher is faster.
 

--- a/TASK/StopAnimTask.md
+++ b/TASK/StopAnimTask.md
@@ -14,5 +14,5 @@ void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float sp
 * **ped**: 
 * **animDictionary**: 
 * **animationName**: 
-* **speed**: Exclusive between `0.0` and `2.0`, higher is faster.
+* **speed**: Greater than `0.0`, higher is faster. Setting to `0.0` or using an integer, will cause animation lockout - requiring the animation to be played again or the player be killed.
 

--- a/TASK/StopAnimTask.md
+++ b/TASK/StopAnimTask.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0x97FF36A1D40EA00A 0x2B520A57
-void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float speed);
+void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float animExitSpeed);
 ```
 
 [Animations list](https://alexguirre.github.io/animations-list/)
@@ -14,5 +14,5 @@ void STOP_ANIM_TASK(Ped ped, char* animDictionary, char* animationName, float sp
 * **ped**: 
 * **animDictionary**: 
 * **animationName**: 
-* **speed**: Greater than `0.0`, higher is faster. Setting to `0.0` or using an integer, will cause animation lockout - requiring the animation to be played again or the player be killed.
+* **animExitSpeed**: Greater than `0.0`, higher is faster. Setting to `0.0` or using an integer, will cause animation lockout - requiring the animation to be played again or the player be killed.
 


### PR DESCRIPTION
'speed' describes the rate at which the ped's animation is stopped, a float greater than `0.0` - `speed >= 0.0`. Providing a value as an integer or outside the argument constraints will result in the native failing silently, as well as resulting in the animation being **locked out** until it is next played.

> The purpose and limitations of this argument was discovered when patching qalle-git/qalle-wheelchair#6.

Including native calls from [qalle-wheelchair (Lines 133 to 149 at `0f97dee7`)](https://github.com/qalle-git/qalle-wheelchair/blob/0f97dee7267cecce617a2a917373bb71eeefc754/client/main.lua#L133-L149) as example.
```lua
TaskPlayAnim(PlayerPedId(), 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
StopAnimTask(PlayerPedId(), 'anim@heists@box_carry@', 'idle', 1.0)
```