### PR TITLE
Edit ped config flag

### DIFF
--- a/PED/SetPedConfigFlag.md
+++ b/PED/SetPedConfigFlag.md
@@ -468,7 +468,7 @@ enum ePedConfigFlags {
 	_0x1D19C622 = 454,
 	_0xB68D3EAB = 455,
 	CPED_CONFIG_FLAG_CanBeIncapacitated = 456,
-	_0x4BD5EBAD = 457,
+	CPED_CONFIG_FLAG_MutableForcedAim = 457
 }
 ```
 


### PR DESCRIPTION
Just like `CPED_CONFIG_FLAG_ForcedAim = 101`, but if you enter the vehicle, this flag will be turned off.