### PR TITLE
GET_SOUND_ID, PLAY_SOUND_FRONTEND, CLEAR_PED_TASKS

### DIFF
--- a/AUDIO/GetSoundId.md
+++ b/AUDIO/GetSoundId.md
@@ -8,5 +8,8 @@ ns: AUDIO
 int GET_SOUND_ID();
 ```
 
+```
+Returns numbers in order until it reaches 100, when it reaches 100 it starts returning -1. This native appearantly blocks sounds played with PLAY_SOUND_FRONTEND; PLAY_SOUND; PLAY_SOUND_FROM_COORD; PLAY_SOUND_FROM_ENTITY.
+```
 
 ## Return value

--- a/AUDIO/PlaySoundFrontend.md
+++ b/AUDIO/PlaySoundFrontend.md
@@ -11,6 +11,7 @@ void PLAY_SOUND_FRONTEND(int soundId, char* audioName, char* audioRef, BOOL p3);
 ```
 List: https://pastebin.com/DCeRiaLJ
 All occurrences as of Cayo Perico Heist DLC (b2189), sorted alphabetically and identical lines removed: https://git.io/JtLxM
+These sounds are only played on client-side, other players won't hear it, if you would like to play a sound at every player, you have to use the PLAY_SOUND native.
 ```
 
 ## Parameters

--- a/TASK/ClearPedTasks.md
+++ b/TASK/ClearPedTasks.md
@@ -9,6 +9,7 @@ void CLEAR_PED_TASKS(Ped ped);
 ```
 
 Clear a ped's tasks. Stop animations and other tasks created by scripts.
+If a player uses this native, on another player's ped, this native triggers clearPedTasksEvent server event, if onesync is enabled.
 
 ## Parameters
 * **ped**: Ped id. Use PlayerPedId() for your own character.

--- a/TASK/ClearPedTasksImmediately.md
+++ b/TASK/ClearPedTasksImmediately.md
@@ -9,6 +9,7 @@ void CLEAR_PED_TASKS_IMMEDIATELY(Ped ped);
 ```
 
 Immediately stops the pedestrian from whatever it's doing. The difference between this and [CLEAR_PED_TASKS](#_0xE1EF3C1216AFF2CD) is that this one teleports the ped but does not change the position of the ped.
+If a player uses this native, on another player's ped, this native triggers clearPedTasksEvent server event, if onesync is enabled.
 
 ## Parameters
 * **ped**: Ped id.


### PR DESCRIPTION
Hello!

I figured out what GET_SOUND_ID does. Explanation: https://prnt.sc/8BnmKykWX-el
I mentioned in PlaySoundFrontend's description that it just plays on client-side, not on server-side, and added natives able to play sounds every player hear.
I added an explanation about clearPedTasksEvent to the CLEAR_PED_TASKS & the CLEAR_PED_TASKS_IMMEDIATELY natives.

Best regards,
Blitoka33

Signed-off-by: Blitoka33 <blitoka33@gmail.com>
