### PR TITLE
Fix(BeginTextCommandSetBlipName): undefined AddBlipForCoords

### DIFF
--- a/HUD/BeginTextCommandSetBlipName.md
+++ b/HUD/BeginTextCommandSetBlipName.md
@@ -20,7 +20,7 @@ This should be paired with [`END_TEXT_COMMAND_SET_BLIP_NAME`](#_0xBC38B49BCB83BC
 -- creates a blip called 'Food for me!' at 0.0, 0.0, 0.0
 AddTextEntry('MYBLIP', 'Food for ~a~!')
 
-local blip = AddBlipForCoords(0.0, 0.0, 0.0)
+local blip = AddBlipForCoord(0.0, 0.0, 0.0)
 BeginTextCommandSetBlipName('MYBLIP')
 AddTextComponentSubstringPlayerName('me')
 EndTextCommandSetBlipName(blip)


### PR DESCRIPTION
`AddBlipForCoords` is undefined. The proper native is [`AddBlipForCoords`](https://docs.fivem.net/natives/?_0x5A039BB0BCA604B6)

**In game:**
![image](https://user-images.githubusercontent.com/43311443/188282859-528bbd00-16b9-47fe-acf9-f16a6591e5bb.png)

**The docs:**
![image](https://user-images.githubusercontent.com/43311443/188282877-2ff062b1-bd05-4473-9e98-b7866a1d7c4a.png)