### PR TITLE
Fix(SetBlipDisplay): displayID not formatting, now to table

### DIFF
--- a/HUD/SetBlipDisplay.md
+++ b/HUD/SetBlipDisplay.md
@@ -9,19 +9,25 @@ void SET_BLIP_DISPLAY(Blip blip, int displayId);
 ```
 
 **displayId Behaviour** <br>
-0 = Doesn't show up, ever, anywhere. <br>
-1 = Doesn't show up, ever, anywhere. <br>
-2 = Shows on both main map and minimap. (Selectable on map) <br>
-3 = Shows on main map only. (Selectable on map) <br>
-4 = Shows on main map only. (Selectable on map) <br>
-5 = Shows on minimap only. <br>
-6 = Shows on both main map and minimap. (Selectable on map) <br>
-7 = Doesn't show up, ever, anywhere. <br>
-8 = Shows on both main map and minimap. (Not selectable on map) <br>
-9 = Shows on minimap only. <br>
-10 = Shows on both main map and minimap. (Not selectable on map) <br>
-Anything higher than 10 seems to be exactly the same as 10. <br>
-<br>
+
+| display ID 	| Behaviour                                                   	|
+|------------	|-------------------------------------------------------------	|
+| 0          	| Doesn't show up, ever, anywhere.                            	|
+| 1          	| Doesn't show up, ever, anywhere.                            	|
+| 2          	| Shows on both main map and minimap. (Selectable on map)     	|
+| 3          	| Shows on main map only. (Selectable on map)                 	|
+| 4          	| Shows on main map only. (Selectable on map)                 	|
+| 5          	| Shows on minimap only.                                      	|
+| 6          	| Shows on both main map and minimap. (Selectable on map)     	|
+| 7          	| Doesn't show up, ever, anywhere.                            	|
+| 8          	| Shows on both main map and minimap. (Not selectable on map) 	|
+| 9          	| Shows on minimap only.                                      	|
+| 10         	| Shows on both main map and minimap. (Not selectable on map) 	|
+
+Anything higher than 10 seems to be exactly the same as 10.
+
+
+
 Rockstar seem to only use 0, 2, 3, 4, 5 and 8 in the decompiled scripts.
 
 ## Parameters

--- a/HUD/SetBlipDisplay.md
+++ b/HUD/SetBlipDisplay.md
@@ -8,7 +8,7 @@ ns: HUD
 void SET_BLIP_DISPLAY(Blip blip, int displayId);
 ```
 
-**displayId Behaviour** <br>
+**displayId Behaviour**
 
 | display ID 	| Behaviour                                                   	|
 |------------	|-------------------------------------------------------------	|
@@ -25,8 +25,6 @@ void SET_BLIP_DISPLAY(Blip blip, int displayId);
 | 10         	| Shows on both main map and minimap. (Not selectable on map) 	|
 
 Anything higher than 10 seems to be exactly the same as 10.
-
-
 
 Rockstar seem to only use 0, 2, 3, 4, 5 and 8 in the decompiled scripts.
 


### PR DESCRIPTION
Changed the `displayID` section from a list with (raw) `<br>` to a Markdown table.

**Before:**
![image](https://user-images.githubusercontent.com/43311443/188290310-896519f7-9933-4f5a-a60e-17a33bcc6b01.png)

**After:**
| display ID 	| Behaviour                                                   	|
|------------	|-------------------------------------------------------------	|
| 0          	| Doesn't show up, ever, anywhere.                            	|
| 1          	| Doesn't show up, ever, anywhere.                            	|
| 2          	| Shows on both main map and minimap. (Selectable on map)     	|
| 3          	| Shows on main map only. (Selectable on map)                 	|
| 4          	| Shows on main map only. (Selectable on map)                 	|
| 5          	| Shows on minimap only.                                      	|
| 6          	| Shows on both main map and minimap. (Selectable on map)     	|
| 7          	| Doesn't show up, ever, anywhere.                            	|
| 8          	| Shows on both main map and minimap. (Not selectable on map) 	|
| 9          	| Shows on minimap only.                                      	|
| 10         	| Shows on both main map and minimap. (Not selectable on map) 	|