### PR TITLE
Update ClearArea* of Cops, Peds and Projectiles.

### DIFF
--- a/MISC/ClearAreaOfCops.md
+++ b/MISC/ClearAreaOfCops.md
@@ -5,17 +5,21 @@ ns: MISC
 
 ```c
 // 0x04F8FC8FCF58F88D 0x95C53824
-void CLEAR_AREA_OF_COPS(float x, float y, float z, float radius, int flags);
+void CLEAR_AREA_OF_COPS(float x, float y, float z, float radius, cs_type(int) BOOL createNetEvent);
 ```
 
-```
-flags appears to always be 0
+Clears an area of cops at the given coordinates and radius.
+
+## Examples
+```lua
+-- Clear the area, do also create an event
+ClearAreaOfCops(0.0, 0.0, 0.0, 10000.0, true)
 ```
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
-* **radius**: 
-* **flags**: 
+* **x**: The x coordinate of where to clear cops.
+* **y**: The y coordinate of where to clear cops.
+* **z**: The z coordinate of where to clear cops.
+* **radius**: The area radius to clear cops.
+* **createNetEvent**: specifies whether a `CClearAreaEvent` event of should be created for online use.
 

--- a/MISC/ClearAreaOfPeds.md
+++ b/MISC/ClearAreaOfPeds.md
@@ -5,17 +5,21 @@ ns: MISC
 
 ```c
 // 0xBE31FD6CE464AC59 0x25BE7FA8
-void CLEAR_AREA_OF_PEDS(float x, float y, float z, float radius, int flags);
+void CLEAR_AREA_OF_PEDS(float x, float y, float z, float radius, cs_type(int) BOOL createNetEvent);
 ```
 
-```
-Example:       CLEAR_AREA_OF_PEDS(0, 0, 0, 10000, 1);
+Clears an area of peds at the given coordinates and radius.
+
+## Examples
+```lua
+-- Clear the area, do also create an event
+ClearAreaOfPeds(0.0, 0.0, 0.0, 10000.0, true)
 ```
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
-* **radius**: 
-* **flags**: 
+* **x**: The x coordinate of where to clear peds.
+* **y**: The y coordinate of where to clear peds.
+* **z**: The z coordinate of where to clear peds.
+* **radius**: The area radius to clear peds.
+* **createNetEvent**: specifies whether a `CClearAreaEvent` event of should be created for online use.
 

--- a/MISC/ClearAreaOfProjectiles.md
+++ b/MISC/ClearAreaOfProjectiles.md
@@ -5,14 +5,22 @@ ns: MISC
 
 ```c
 // 0x0A1CB9094635D1A6 0x18DB5434
-void CLEAR_AREA_OF_PROJECTILES(float x, float y, float z, float radius, cs_type(BOOL) int flags);
+void CLEAR_AREA_OF_PROJECTILES(float x, float y, float z, float radius, cs_type(int) BOOL createNetEvent);
+```
+
+Clears an area of projectiles at the given coordinates and radius.
+
+## Examples
+```lua
+-- Clear the area, do also create an event
+ClearAreaOfProjectiles(0.0, 0.0, 0.0, 10000.0, true)
 ```
 
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
-* **radius**: 
-* **flags**: 
+* **x**: The x coordinate of where to clear projectiles.
+* **y**: The y coordinate of where to clear projectiles.
+* **z**: The z coordinate of where to clear projectiles.
+* **radius**: The area radius to clear projectiles.
+* **createNetEvent**: specifies whether a `CClearAreaEvent` event of should be created for online use.
 


### PR DESCRIPTION
This PR modifies an incorrectly named parameter in the aforementioned natives. 
The parameter was previously named `flags`, but this parameter actually defines whether a net event of `CClearAreaEvent` should be created or not upon native execution.

I'm not entirely sure if changing parameter types is ok to do so (as in won't break anything, never done such thing), if so I can just set the type back to integer, let me know if so, thanks.