### PR TITLE
Update SetSuperJumpThisFrame and other natives

### DIFF
--- a/MISC/SetSuperJumpThisFrame.md
+++ b/MISC/SetSuperJumpThisFrame.md
@@ -8,7 +8,24 @@ ns: MISC
 cs_type(int) void SET_SUPER_JUMP_THIS_FRAME(Player player);
 ```
 
+Allows the player to perform super jumps. This function must be called every frame for it to work.
+It basically OR's a flag for a single frame, allowing the ped to perform a super jump only when the flag is set.
+
+
 ## Parameters
-* **player**: 
+* **player**: The player we are setting this for.
 
 ## Return value
+
+## Examples
+```lua
+Citizen.CreateThread(function()
+    while true do
+        SetSuperJumpThisFrame(PlayerId())
+        -- Try enabling the two down below if you also want invincibility and no ragdoll effects
+        --SetPlayerInvincible(PlayerId(), true)
+        --SetPedCanRagdoll(PlayerPedId(), false)
+        Citizen.Wait(0)
+    end
+end)
+```

--- a/PLAYER/GetPlayersLastVehicle.md
+++ b/PLAYER/GetPlayersLastVehicle.md
@@ -8,8 +8,11 @@ ns: PLAYER
 Vehicle GET_PLAYERS_LAST_VEHICLE();
 ```
 
-```
-Alternative: GET_VEHICLE_PED_IS_IN(PLAYER_PED_ID(), 1);  
-```
+### Warning
+This native will return `0` if the last vehicle the player was in was destroyed.
+
+### Alternative
+You can use [GET_VEHICLE_PED_IS_IN](#_0x9A9112A0FE9A4713), which will actually get the last vehicle, even if it was destroyed.
 
 ## Return value
+A vehicle handle containing the last player's vehicle.

--- a/VEHICLE/GetVehicleCauseOfDestruction.md
+++ b/VEHICLE/GetVehicleCauseOfDestruction.md
@@ -8,16 +8,21 @@ ns: VEHICLE
 Hash GET_VEHICLE_CAUSE_OF_DESTRUCTION(Vehicle vehicle);
 ```
 
-```
-iVar3 = get_vehicle_cause_of_destruction(uLocal_248[iVar2]);  
-if (iVar3 == joaat("weapon_stickybomb"))  
-{  
-     func_171(726);  
-     iLocal_260 = 1;  
-}  
-```
 
 ## Parameters
-* **vehicle**: 
+* **vehicle**: The vehicle to get the cause of destruction of.
 
 ## Return value
+A hash representing the destruction cause. These can be weapon hashes.
+
+## Examples
+```lua
+local destructionCauseHash = GetVehicleCauseOfDestruction(GetVehiclePedIsIn(PlayerPedId(), true))
+if destructionCauseHash == GetHashKey("weapon_stickybomb") then
+     -- It looks like the vehicle was destroyed by a sticky bomb
+     Citizen.Trace('Vehicle was destroyed by a sticky bomb!')
+elseif destructionCauseHash ~= 0 then
+     -- It looks like the vehicle was destroyed by something else!
+     Citizen.Trace('Vehicle was destroyed by: ' .. destructionCauseHash)
+end
+```


### PR DESCRIPTION
This PR documents:

- SetSuperJumpThisFrame
- GetPlayersLastVehicle
- GetVehicleCauseOfDestruction

A user on Discord asked for source code regarding
`SetSuperJumpThisFrame` I believe they didn't know how to use the native, so I documented it anyway.

Upon documenting `GetVehicleCauseOfDestruction` (since the given example was some code from the game's decompiled scripts) I noticed that `GetPlayersLastVehicle` was of no use if the vehicle to get was previously destroyed, so I documented on that too.
