### PR TITLE
fix(vehicle/IsVehicleWindowIntact): eWindowId enum

### DIFF
--- a/VEHICLE/IsVehicleWindowIntact.md
+++ b/VEHICLE/IsVehicleWindowIntact.md
@@ -10,19 +10,19 @@ BOOL IS_VEHICLE_WINDOW_INTACT(Vehicle vehicle, int windowIndex);
 
 ```c
 enum eWindowId {
-	VEH_EXT_WINDSCREEN = 0,
-	VEH_EXT_WINDSCREEN_R = 1,
-	VEH_EXT_WINDOW_LF = 2,
-	VEH_EXT_WINDOW_RF = 3,
-	VEH_EXT_WINDOW_LR = 4,
-	VEH_EXT_WINDOW_RR = 5,
-	VEH_EXT_WINDOW_LM = 6,
-	VEH_EXT_WINDOW_RM = 7,
+	VEH_EXT_WINDOW_LF = 0,
+	VEH_EXT_WINDOW_RF = 1,
+	VEH_EXT_WINDOW_LR = 2,
+	VEH_EXT_WINDOW_RR = 3,
+	VEH_EXT_WINDOW_LM = 4,
+	VEH_EXT_WINDOW_RM = 5,
+	VEH_EXT_WINDSCREEN = 6,
+	VEH_EXT_WINDSCREEN_R = 7,
 }
 ```
 
 ## Parameters
-* **vehicle**: 
-* **windowIndex**: 
+* **vehicle**: The vehicle handle
+* **windowIndex**: The index of the window
 
 ## Return value


### PR DESCRIPTION
I have tested the natives IS_VEHICLE_WINDOW_INTACT, ROLL_WINDOW_DOWN, ROLL_WINDOW_UP, SMASH_VEHICLE_WINDOW and FIX_VEHICLE_WINDOW and after going through the indexes 0-7 I have found that the order of the enum on the docs weren't correct, so this PR fixes that
