### PR TITLE
Add missing argument and improve documentation

### DIFF
--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -5,18 +5,19 @@ ns: NETWORK
 
 ```c
 // 0x1F4ED342ACEFE62D 0x9B9FCD02
-void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL flash, BOOL slow);
+void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL flash);
 ```
 
 Fade the given entity back in, usually used after the entity has been faded out with [NETWORK_FADE_OUT_ENTITY](#_0xDE564951F95E09ED)
 
 When used on a entity which isn't invisible or faded out then the native will still work, it will just instanly make the ped invisible before fading in.
 
+Note that there is another boolean parameter which is missing, when set to true the fade in will be a little bit slower.
+
 
 ## Parameters
 * **entity**: The entity to fade in
 * **flash**: When set to true the entity will flash rapidly while fading out
-* **slow**: When set to true the fadein will be a little bit slower than normal
 
 ## Examples
 
@@ -28,6 +29,7 @@ end
 
 --- Do something like a teleport, or warp into a vehicle
 
+-- Last parameter here is slow, this parameter is missing in decleration
 NetworkFadeInEntity(PlayerPedId(), false, false)
 while NetworkIsEntityFading(PlayerPedId()) do
   Citizen.Wait(0)

--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -5,14 +5,15 @@ ns: NETWORK
 
 ```c
 // 0x1F4ED342ACEFE62D 0x9B9FCD02
-void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL flash);
+void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL bNetwork);
 ```
 
 Fade the given entity back in, usually used after the entity has been faded out with [NETWORK_FADE_OUT_ENTITY](#_0xDE564951F95E09ED)
 
 When used on a entity which isn't invisible or faded out then the native will still work, it will just instanly make the ped invisible before fading in.
 
-Note that there is another boolean parameter which is missing, when set to true the fade in will be a little bit slower.
+**Additional Parameters**:
+* **flash**: If set to true the entity will flash while fading in.
 
 
 ## Parameters

--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -5,7 +5,7 @@ ns: NETWORK
 
 ```c
 // 0x1F4ED342ACEFE62D 0x9B9FCD02
-void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL state);
+void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL flash, BOOL slow);
 ```
 
 Fade the given entity back in, usually used after the entity has been faded out with [NETWORK_FADE_OUT_ENTITY](#_0xDE564951F95E09ED)

--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -18,21 +18,24 @@ When used on a entity which isn't invisible or faded out then the native will st
 
 ## Parameters
 * **entity**: The entity to fade in
-* **flash**: When set to true the entity will flash rapidly while fading out
+* **network**: When set to true the fade in will be networked.
 
 ## Examples
 
 ```lua
-NetworkFadeOutEntity(PlayerPedId(), false, false)
-while NetworkIsEntityFading(PlayerPedId()) do
-  Citizen.Wait(0)
+local playerPed = PlayerPedId()
+
+-- fade out the player while flashing them
+NetworkFadeOutEntity(playerPed, true, false)
+while NetworkIsEntityFading(playerPed) do
+  Wait(0)
 end
 
 --- Do something like a teleport, or warp into a vehicle
 
--- Last parameter here is slow, this parameter is missing in decleration
-NetworkFadeInEntity(PlayerPedId(), false, false)
-while NetworkIsEntityFading(PlayerPedId()) do
-  Citizen.Wait(0)
+-- while generally frowned upon when you can use natives, this declaration has
+-- a missing parameter, which doesn't work without manually invoking.
+Citizen.InvokeNative(0x1F4ED342ACEFE62D, playerPed, false, true)
+while NetworkIsEntityFading(playerPed) do
+  Wait(0)
 end
-```

--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -18,7 +18,7 @@ When used on a entity which isn't invisible or faded out then the native will st
 
 ## Parameters
 * **entity**: The entity to fade in
-* **network**: When set to true the fade in will be networked.
+* **bNetwork**: When set to true the fade in will be networked.
 
 ## Examples
 

--- a/NETWORK/NetworkFadeInEntity.md
+++ b/NETWORK/NetworkFadeInEntity.md
@@ -8,17 +8,28 @@ ns: NETWORK
 void NETWORK_FADE_IN_ENTITY(Entity entity, BOOL state);
 ```
 
-```
-state - 0 does 5 fades  
-state - 1 does 6 fades  
-native is missing third argument, also boolean, setting to 1 made vehicle fade in slower, probably "slow" as per NETWORK_FADE_OUT_ENTITY  
-```
+Fade the given entity back in, usually used after the entity has been faded out with [NETWORK_FADE_OUT_ENTITY](#_0xDE564951F95E09ED)
 
-```
-NativeDB Added Parameter 3: BOOL slow
-```
+When used on a entity which isn't invisible or faded out then the native will still work, it will just instanly make the ped invisible before fading in.
+
 
 ## Parameters
-* **entity**: 
-* **state**: 
+* **entity**: The entity to fade in
+* **flash**: When set to true the entity will flash rapidly while fading out
+* **slow**: When set to true the fadein will be a little bit slower than normal
 
+## Examples
+
+```lua
+NetworkFadeOutEntity(PlayerPedId(), false, false)
+while NetworkIsEntityFading(PlayerPedId()) do
+  Citizen.Wait(0)
+end
+
+--- Do something like a teleport, or warp into a vehicle
+
+NetworkFadeInEntity(PlayerPedId(), false, false)
+while NetworkIsEntityFading(PlayerPedId()) do
+  Citizen.Wait(0)
+end
+```


### PR DESCRIPTION
I'm not 100% sure as to what the arguments do exactly because the behavior of the native changes depending on whether oal is enabled or not, not sure what's going on there, I'm assuming this is due to the missing argument.

Without OAL it always does the non flashing fade in, and with OAL it always does the flashing fade in, even though this is not the actual missing argument.
