### PR TITLE
Extend the documentation for SetFloatingHelpTextStyle

### DIFF
--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -8,7 +8,14 @@ aliases: ["0x788E7FD431BD67F1"]
 // 0x788E7FD431BD67F1 0x97852A82
 void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int p3, int arrowPosition, int boxOffset);
 ```
-Needs to be called every frame
+
+## Parameters
+* **hudIndex**: 
+* **style**: 0: No arrow at all. 1, 2 and -2 are all the same and displaying a arrow (if specified)
+* **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
+* **p3**: No use case. Always 191 in R* scripts
+* **arrowPosition**: Used to set the arrow positon. Default is off
+* **boxOffset**: Offset for the floating help box. Important: Arrow stays fixed on its position
 
 ## Arrow Positions
 0 = OFF  
@@ -18,6 +25,9 @@ Needs to be called every frame
 4 = RIGHT  
 
 Note: anything above 4 will result in a right arrow
+
+## Important
+Needs to be called every frame
 
 ## Example
 ```lua
@@ -40,11 +50,3 @@ CreateThread(function()
 end)
 ```
 ![](https://derdevhd.live/media/example.png)
-
-## Parameters
-* **hudIndex**: 
-* **style**: 0: No arrow at all. 1, 2 and -2 are all the same and displaying a arrow (if specified)
-* **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
-* **p3**: No use case. Always 191 in R* scripts
-* **arrowPosition**: Used to set the arrow positon. Default is off
-* **boxOffset**: Offset for the floating help box. Important: Arrow stays fixed on its position

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -10,21 +10,22 @@ void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int p3,
 ```
 
 ## Parameters
-* **hudIndex**: 
-* **style**: 0: No arrow at all. 1, 2 and -2 are all the same and displaying a arrow (if specified)
+* **hudIndex**: The hud index for the floating help message
+* **style**: Value 0 won't show an arrow at all. Values 1, 2 and -2 will display an arrow.
 * **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
 * **p3**: No use case. Always 191 in R* scripts
-* **arrowPosition**: Used to set the arrow positon. Default is off
-* **boxOffset**: Offset for the floating help box. Important: Arrow stays fixed on its position
+* **arrowPosition**: Used to set the arrow positon. No value will hide the arrow
+* **boxOffset**: Offset for the floating help box. Note: Arrow stays fixed
 
 ## Arrow Positions
-0 = OFF  
-1 = TOP  
-2 = LEFT  
-3 = BOTTOM  
-4 = RIGHT  
+* 0 = Off / No arrow
+* 1 = Top
+* 2 = Left
+* 3 = Bottom
+* 4 = Right
 
-Note: anything above 4 will result in a right arrow
+### Note
+Any numeric value greater than 4 will result in a right arrow (Index 4)
 
 ## Important
 Needs to be called every frame
@@ -34,7 +35,7 @@ Needs to be called every frame
 function DisplayHelpText(string)
     BeginTextCommandDisplayHelp("STRING")
     AddTextComponentSubstringPlayerName(string)
-    EndTextCommandDisplayHelp(1, 0, 0, 0)
+    EndTextCommandDisplayHelp(1, false, false, 0)
 end
 
 CreateThread(function()
@@ -49,4 +50,4 @@ CreateThread(function()
     end
 end)
 ```
-![](https://derdevhd.live/media/example.png)
+![](todo)

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -6,14 +6,45 @@ aliases: ["0x788E7FD431BD67F1"]
 
 ```c
 // 0x788E7FD431BD67F1 0x97852A82
-void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int p1, int p2, int p3, int p4, int p5);
+void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int p3, int arrowPosition, int boxOffset);
 ```
+Needs to be called every frame
+
+## Arrow Positions
+0 = OFF  
+1 = TOP  
+2 = LEFT  
+3 = BOTTOM  
+4 = RIGHT  
+
+Note: anything above 4 will result in a right arrow
+
+## Example
+```lua
+function DisplayHelpText(string)
+    BeginTextCommandDisplayHelp("STRING")
+    AddTextComponentSubstringPlayerName(string)
+    EndTextCommandDisplayHelp(1, 0, 0, 0)
+end
+
+CreateThread(function()
+    while true do
+        Wait(0)
+
+        local Ped = PlayerPedId()
+
+        DisplayHelpText('Example Text')
+        SetFloatingHelpTextStyle(0, 2, 2, 0, 3, 0)
+        SetFloatingHelpTextToEntity(0, Ped, 0, 0)
+    end
+end)
+```
+![](https://derdevhd.live/media/example.png)
 
 ## Parameters
 * **hudIndex**: 
-* **p1**: 
-* **p2**: 
-* **p3**: 
-* **p4**: 
-* **p5**: 
-
+* **style**: 0: No arrow at all. 1, 2 and -2 are all the same and displaying a arrow (if specified)
+* **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
+* **p3**: No use case. Always 191 in R* scripts
+* **arrowPosition**: Used to set the arrow positon. Default is off
+* **boxOffset**: Offset for the floating help box. Important: Arrow stays fixed on its position

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -22,7 +22,7 @@ Any numeric value greater than 4 will result in a right arrow (Index 4)
 ### Important
 Needs to be called every frame
 
-![Preview of the provided example code](https://i.ibb.co/G97hPn7/Image.png)
+![Preview of the provided example code](https://forum.cfx.re/uploads/default/original/4X/7/f/3/7f319bc93c3a00b8829bd4ac8dddc235fbf3a9ef.png)
 
 ## Parameters
 * **hudIndex**: The hud index for the floating help message

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -9,14 +9,6 @@ aliases: ["0x788E7FD431BD67F1"]
 void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int alpha, int arrowPosition, int boxOffset);
 ```
 
-## Parameters
-* **hudIndex**: The hud index for the floating help message
-* **style**: Value 0 won't show an arrow at all. Values 1, 2 and -2 will display an arrow.
-* **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
-* **alpha**: Value for the help box opacity, from 0-255. Anything greater will simply ignore the alpha value. Always 191 in R* scripts.
-* **arrowPosition**: Used to set the arrow positon. No value will hide the arrow
-* **boxOffset**: Offset for the floating help box. Note: Arrow stays fixed
-
 ### Arrow Positions
 * 0 = Off / No arrow
 * 1 = Top
@@ -29,6 +21,16 @@ Any numeric value greater than 4 will result in a right arrow (Index 4)
 
 ### Important
 Needs to be called every frame
+
+![Preview of the provided example code](https://i.ibb.co/G97hPn7/Image.png)
+
+## Parameters
+* **hudIndex**: The hud index for the floating help message
+* **style**: Value 0 won't show an arrow at all. Values 1, 2 and -2 will display an arrow.
+* **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
+* **alpha**: Value for the help box opacity, from 0-255. Anything greater will simply ignore the alpha value. Always 191 in R* scripts.
+* **arrowPosition**: Used to set the arrow positon. No value will hide the arrow
+* **boxOffset**: Offset for the floating help box. Note: Arrow stays fixed
 
 ## Examples
 ```lua
@@ -66,4 +68,3 @@ setTick(() => {
     SetFloatingHelpTextToEntity(0, Ped, 0, 0)
 })
 ```
-![Preview of the example above](https://i.ibb.co/G97hPn7/Image.png)

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -6,18 +6,18 @@ aliases: ["0x788E7FD431BD67F1"]
 
 ```c
 // 0x788E7FD431BD67F1 0x97852A82
-void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int p3, int arrowPosition, int boxOffset);
+void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int alpha, int arrowPosition, int boxOffset);
 ```
 
 ## Parameters
 * **hudIndex**: The hud index for the floating help message
 * **style**: Value 0 won't show an arrow at all. Values 1, 2 and -2 will display an arrow.
 * **hudColor**: https://docs.fivem.net/docs/game-references/hud-colors/
-* **p3**: No use case. Always 191 in R* scripts
+* **alpha**: Value for the help box opacity, from 0-255. Anything greater will simply ignore the alpha value. Always 191 in R* scripts.
 * **arrowPosition**: Used to set the arrow positon. No value will hide the arrow
 * **boxOffset**: Offset for the floating help box. Note: Arrow stays fixed
 
-## Arrow Positions
+### Arrow Positions
 * 0 = Off / No arrow
 * 1 = Top
 * 2 = Left
@@ -27,10 +27,10 @@ void SET_FLOATING_HELP_TEXT_STYLE(int hudIndex, int style, int hudColor, int p3,
 ### Note
 Any numeric value greater than 4 will result in a right arrow (Index 4)
 
-## Important
+### Important
 Needs to be called every frame
 
-## Example
+## Examples
 ```lua
 function DisplayHelpText(string)
     BeginTextCommandDisplayHelp("STRING")
@@ -50,4 +50,20 @@ CreateThread(function()
     end
 end)
 ```
-![](todo)
+
+```js
+function DisplayHelpText(string) {
+    BeginTextCommandDisplayHelp("STRING")
+    AddTextComponentSubstringPlayerName(string)
+    EndTextCommandDisplayHelp(1, false, false, 0)
+}
+
+setTick(() => {
+    const Ped = PlayerPedId()
+
+    DisplayHelpText('Example Text')
+    SetFloatingHelpTextStyle(0, 2, 2, 0, 3, 0)
+    SetFloatingHelpTextToEntity(0, Ped, 0, 0)
+})
+```
+![Preview of the example above](https://i.ibb.co/9p7VWDW/image.png)

--- a/HUD/SetFloatingHelpTextStyle.md
+++ b/HUD/SetFloatingHelpTextStyle.md
@@ -66,4 +66,4 @@ setTick(() => {
     SetFloatingHelpTextToEntity(0, Ped, 0, 0)
 })
 ```
-![Preview of the example above](https://i.ibb.co/9p7VWDW/image.png)
+![Preview of the example above](https://i.ibb.co/G97hPn7/Image.png)


### PR DESCRIPTION
# Introduction
I have done some research about the argument(-names) for the native SetFloatingHelpTextStyle.
For proper analysation I used several sources for the documentation, including the decompiled script `freemode.c`, aswell as a decompiled Scaleform from the base game.

# Updates
**p1** --> **style**
**p2** --> **hudColor**
**p3** --> **alpha** *Thank you 4mmonium*
**p4** --> **arrowPosition**
**p5** --> **boxOffset**

# Example
A very simple little code snippet, used for testing the parameters
```lua
function DisplayHelpText(string)
    BeginTextCommandDisplayHelp("STRING")
    AddTextComponentSubstringPlayerName(string)
    EndTextCommandDisplayHelp(1, false, false, 0)
end

CreateThread(function()
    while true do
        Wait(0)

        local Ped = PlayerPedId()

        DisplayHelpText('Example Text')
        SetFloatingHelpTextStyle(0, 2, 2, 0, 3, 0)
        SetFloatingHelpTextToEntity(0, Ped, 0, 0)
    end
end)
```

## Preview of the code above
// todo
![](TODO)