### PR TITLE
switch p3 & p6

### DIFF
--- a/VEHICLE/AttachVehicleToTowTruck.md
+++ b/VEHICLE/AttachVehicleToTowTruck.md
@@ -5,7 +5,7 @@ ns: VEHICLE
 
 ```c
 // 0x29A16F8D621C4508 0x8151571A
-void ATTACH_VEHICLE_TO_TOW_TRUCK(Vehicle towTruck, Vehicle vehicle, BOOL rear, float hookOffsetX, float hookOffsetY, float hookOffsetZ);
+void ATTACH_VEHICLE_TO_TOW_TRUCK(Vehicle towTruck, Vehicle vehicle, float hookOffsetX, float hookOffsetY, float hookOffsetZ, BOOL rear);
 ```
 
 ```
@@ -14,9 +14,9 @@ HookOffset defines where the hook is attached. leave at 0 for default attachment
 
 ## Parameters
 * **towTruck**: 
-* **vehicle**: 
-* **rear**: 
+* **vehicle**:  
 * **hookOffsetX**: 
 * **hookOffsetY**: 
 * **hookOffsetZ**: 
+* **rear**:
 


### PR DESCRIPTION
Upon testing with a bool variable determined by checking bone distances, p3 and p6 are labeled backwards.

targetRear is the bool I define from the dist checks AttachVehicleToTowTruck(veh,target,0.0,0.0,0.0,targetRear)

When using as published before, the connection would only go to the rear and the hook was completely away from the car

Before you submit this PR, please make sure:

- You have read the contribution guidelines
- You include an example that validates your change
- Your English is grammatically correct
