### PR TITLE
Compatibility generation (manual only)

### DIFF
--- a/.ci/run-compat
+++ b/.ci/run-compat
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# configuration
+GENERATOR_PATH="$1/compatgen.js"
+OUTPUT_FILE=${2:-"./out/natives_global_client_compat.lua"}
+INPUT_FILE=${3:-"./in/natives_global_client_compat.lua"}
+IGNORE_MISSING_INPUT=${4:-false}
+FORCE_UPDATE=${5:-false}
+USE_HISTORY=${6:-false}
+DAYS_SINCE_DATE=${7:-2023-01-01} #YYYY-MM-DD
+VERSION=${8:-2.0}
+
+# execution
+node $GENERATOR_PATH --set-version=$VERSION --force=$FORCE_UPDATE --out=$OUTPUT_FILE --in=$INPUT_FILE --ignore-missing-in=$IGNORE_MISSING_INPUT --use-history=$USE_HISTORY --start-date=$DAYS_SINCE_DATE

--- a/.ci/setup-builder
+++ b/.ci/setup-builder
@@ -3,13 +3,15 @@
 set -eu
 
 # include common script
-. "$(dirname "$0")"/common.sh
+. "$(dirname "$BASH_SOURCE")"/common.sh
 
 sudo ln -s libclang-10.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
 
 mkdir -p $BUILDER_ROOT
 cd $BUILDER_ROOT
 
-git clone https://github.com/citizenfx/native-doc-tooling.git .
-git checkout b45ca5ae80b8654e5ea28ee81e6dedd7947f9ca7
+git init -q .
+git fetch -q --depth=1 https://github.com/citizenfx/native-doc-tooling.git 2a680c075e73d2c23369a115922284384fcb2cbd
+git checkout FETCH_HEAD
+
 yarn

--- a/.github/workflows/run-compatgen.yml
+++ b/.github/workflows/run-compatgen.yml
@@ -1,0 +1,96 @@
+name: Compatibility method generation
+on:
+  workflow_dispatch:
+    inputs:
+      use_history:
+        type: boolean
+        default: true
+        description: "Get all signatures since date (-h)"
+      since_date:
+        type: string
+        default: '2023-01-01'
+        required: true
+        description: "Since/start date (--start-date)"
+      ignore_missing_input:
+        type: boolean
+        default: false
+        description: "Ignore missing input, needed for initial runs (-i)"
+      no_input:
+        type: boolean
+        default: false
+        description: "Don't load the input file (--in=skip)"
+      force:
+        type: boolean
+        default: false
+        description: "Force output file creation (-f)"
+      output_action:
+        type: choice
+        default: "Ignore"
+        required: true
+        description: "Output file action"
+        options:
+        - Ignore
+        - Echo (stdout)
+        - Artifact
+        - Deploy to remote
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    name: Build & Deploy
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with: 
+          path: './'
+          fetch-depth: 2
+      
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+      
+      - name: Install SSH key
+        if: inputs.no_input == false || inputs.output_action == 'Deploy to remote'
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.NATIVE_DEPLOY_KEY }}
+          known_hosts: ${{ secrets.NATIVE_DEPLOY_KNOWN_HOSTS }}
+      
+      - name: Acquire latest compat file
+        if: inputs.no_input == false
+        env:
+          NATIVE_DEPLOY_URL: ${{ secrets.NATIVE_DEPLOY_URL }}
+        run: |
+          mkdir ./in
+          rsync -q --ignore-missing-args $NATIVE_DEPLOY_URL/natives_global_client_compat.lua ./in/natives_global_client_compat.lua
+      
+      - name: Run build
+        shell: bash
+        run: |
+          set -xe          
+          git fetch --shallow-since=${{ inputs.since_date }}
+          
+          pushd ./
+          . ./.ci/setup-builder
+          popd
+          
+          mkdir -p out
+          [ input.no_input == 'false' ] && INPUT_FILE="./in/natives_global_client_compat.lua" || INPUT_FILE="skip"
+          
+          ./.ci/run-compat $BUILDER_ROOT "./out/natives_global_client_compat.lua" "$INPUT_FILE" ${{ inputs.ignore_missing_input }} ${{ inputs.force }} ${{ inputs.since_date }}
+          
+      - name: Output -> Echo (stdout)
+        if: inputs.output_action == 'Echo (stdout)'
+        run: cat ./out/natives_global_client_compat.lua
+      
+      - name: Output -> Artifact
+        if: inputs.output_action == 'Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ouput-data
+          path: out/*
+      
+      - name: Output -> Deploy
+        if: inputs.output_action == 'Deploy to remote'
+        env:
+          NATIVE_DEPLOY_URL: ${{ secrets.NATIVE_DEPLOY_URL }}
+        run: rsync -rqb --backup-dir=./ --suffix=.bak --include=*compat.lua --exclude=* ./out/ $NATIVE_DEPLOY_URL


### PR DESCRIPTION
*not a native declaration update

Native compatibility generation for manual activation and testing.
* Does not activate on pull requests or any other than manual activation.

.ci/setup-builder
 * Use `$BASH_SOURCE` instead of `$0` allowing it to be included as well (`source`/`.`),
 * Shallow checkout of a specific commit from `native-doc-tooling`, no longer downloading its full history.

Notes:
 * use of rsync's NATIVE_DEPLOY_URL constants may not be correct as I don't know the format of its contents.