### PR TITLE
Compatgen: fix `processing shallow info: 4`

### DIFF
--- a/.ci/setup-builder
+++ b/.ci/setup-builder
@@ -11,7 +11,7 @@ mkdir -p $BUILDER_ROOT
 cd $BUILDER_ROOT
 
 git init -q .
-git fetch -q --depth=1 https://github.com/citizenfx/native-doc-tooling.git 2a680c075e73d2c23369a115922284384fcb2cbd
+git fetch -q --depth=1 https://github.com/citizenfx/native-doc-tooling.git 59821abdd96caf23be103bfa0da3c799ce690df9
 git checkout FETCH_HEAD
 
 yarn

--- a/.github/workflows/run-compatgen.yml
+++ b/.github/workflows/run-compatgen.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Run build
         shell: bash
         run: |
-          set -xe          
-          git fetch --shallow-since=${{ inputs.since_date }}
+          set -xe
+          git fetch origin $GITHUB_REF_NAME --shallow-since=${{ inputs.since_date }}
           
           pushd ./
           . ./.ci/setup-builder
@@ -76,7 +76,7 @@ jobs:
           mkdir -p out
           [ input.no_input == 'false' ] && INPUT_FILE="./in/natives_global_client_compat.lua" || INPUT_FILE="skip"
           
-          ./.ci/run-compat $BUILDER_ROOT "./out/natives_global_client_compat.lua" "$INPUT_FILE" ${{ inputs.ignore_missing_input }} ${{ inputs.force }} ${{ inputs.since_date }}
+          ./.ci/run-compat $BUILDER_ROOT "./out/natives_global_client_compat.lua" "$INPUT_FILE" ${{ inputs.ignore_missing_input }} ${{ inputs.force }} ${{ inputs.use_history }} ${{ inputs.since_date }}
           
       - name: Output -> Echo (stdout)
         if: inputs.output_action == 'Echo (stdout)'


### PR DESCRIPTION
*not a native declaration update

Fix for git error: `fatal: error processing shallow info: 4` when trying to get shallow info on other branches
* git fetch will now only get shallow info of the current branch,
* use patched version of the compat generator citizenfx/native-doc-tooling@59821abdd96caf23be103bfa0da3c799ce690df9 fixing errors that came to light fixing the above issue.