### PR TITLE
Compatgen: fix `no_input` conditional

### DIFF
--- a/.github/workflows/run-compatgen.yml
+++ b/.github/workflows/run-compatgen.yml
@@ -74,7 +74,7 @@ jobs:
           popd
           
           mkdir -p out
-          [ input.no_input == 'false' ] && INPUT_FILE="./in/natives_global_client_compat.lua" || INPUT_FILE="skip"
+          [ ${{ inputs.no_input }} == false ] && INPUT_FILE="./in/natives_global_client_compat.lua" || INPUT_FILE="skip"
           
           ./.ci/run-compat $BUILDER_ROOT "./out/natives_global_client_compat.lua" "$INPUT_FILE" ${{ inputs.ignore_missing_input }} ${{ inputs.force }} ${{ inputs.use_history }} ${{ inputs.since_date }}
           


### PR DESCRIPTION
*not a native declaration update

Conditional check wasn't substituting the left side with its contents, due to missing ${{}} and a spelling error.