### PR TITLE
GetGroundZAndNormalFor_3dCoord in recent versions

### DIFF
--- a/MISC/GetGroundZAndNormalFor_3dCoord.md
+++ b/MISC/GetGroundZAndNormalFor_3dCoord.md
@@ -17,3 +17,4 @@ BOOL GET_GROUND_Z_AND_NORMAL_FOR_3D_COORD(float x, float y, float z, float* grou
 * **normal**: 
 
 ## Return value
+


### PR DESCRIPTION
Seems that it does not work on latest versions, resaulting in error SCRIPT ERROR: Execution of native 8bdc7bfc57a81e76 in script host failed: Error executing native 0x8bdc7bfc57a81e76 at address FiveM_b2699_GTAProcess.exe+15CFAB9

Before you submit this PR, please make sure:

- You have read the contribution guidelines
- You include an example that validates your change
- Your English is grammatically correct
