### PR TITLE
Update AddTextComponentSubstringKeyboardDisplay.md

### DIFF
--- a/HUD/AddTextComponentSubstringKeyboardDisplay.md
+++ b/HUD/AddTextComponentSubstringKeyboardDisplay.md
@@ -9,6 +9,8 @@ aliases: ["_ADD_TEXT_COMPONENT_STRING3","_ADD_TEXT_COMPONENT_SCALEFORM"]
 void ADD_TEXT_COMPONENT_SUBSTRING_KEYBOARD_DISPLAY(char* string);
 ```
 
+Certain characters like `<` will have to be escaped using html entities (e.g. `&lt;`), otherwise the text wont display properly.
+
 ## Parameters
 * **string**: 
 


### PR DESCRIPTION
I noticed when trying to draw a text including "<" it would draw the text up until that character and then stop. After experimenting with a bunch of different escape characters, i figured out you are able to use html entities to escape those characters.