### PR TITLE
Link patch 2

### DIFF
--- a/GRAPHICS/EnableAlienBloodVfx.md
+++ b/GRAPHICS/EnableAlienBloodVfx.md
@@ -9,10 +9,10 @@ aliases: ["0x9DCE1F0F78260875"]
 void ENABLE_ALIEN_BLOOD_VFX(BOOL toggle);
 ```
 
-Creates a motion-blur sort of effect, this native does not seem to work, however by using the [`START_SCREEN_EFFECT`](#_0x2206BF9A37B7F724) native with `"DrugsMichaelAliensFight"` as the effect parameter, you should be able to get the effect.
+Creates a motion-blur sort of effect, this native does not seem to work, however by using the [`ANIMPOSTFX_PLAY`](#_0x2206BF9A37B7F724) native with `"DrugsMichaelAliensFight"` as the effect parameter, you should be able to get the effect.
 
 
-This native does not seem to work, however by using the [START_SCREEN_EFFECT](https://runtime.fivem.net/doc/natives/#_0x2206BF9A37B7F724) native with "DrugsMichaelAliensFight" as the effect parameter, you should be able to get the effect.
+This native does not seem to work, however by using the [ANIMPOSTFX_PLAY](#_0x2206BF9A37B7F724) native with "DrugsMichaelAliensFight" as the effect parameter, you should be able to get the effect.
 
 
 

--- a/GRAPHICS/TerraingridActivate.md
+++ b/GRAPHICS/TerraingridActivate.md
@@ -10,7 +10,7 @@ void TERRAINGRID_ACTIVATE(BOOL toggle);
 ```
 
 This native enables/disables the gold putting grid display (https://i.imgur.com/TC6cku6.png).
-This requires these two natives to be called as well to configure the grid: [`0x1c4fc5752bcd8e48`](https://runtime.fivem.net/doc/reference.html#_0x1C4FC5752BCD8E48) and [`0x5ce62918f8d703c7`](https://runtime.fivem.net/doc/reference.html#_0x5CE62918F8D703C7).
+This requires these two natives to be called as well to configure the grid: [`TERRAINGRID_SET_PARAMS`](#_0x1C4FC5752BCD8E48) and [`TERRAINGRID_SET_COLOURS`](#_0x5CE62918F8D703C7).
 
 
 

--- a/GRAPHICS/TerraingridSetColours.md
+++ b/GRAPHICS/TerraingridSetColours.md
@@ -10,7 +10,7 @@ void TERRAINGRID_SET_COLOURS(int lowR, int lowG, int lowB, int lowAlpha, int R, 
 ```
 
 
-This native is used along with these two natives: [`0xa356990e161c9e65`](https://runtime.fivem.net/doc/reference.html#_0xA356990E161C9E65) and [`0x1c4fc5752bcd8e48`](https://runtime.fivem.net/doc/reference.html#_0x1C4FC5752BCD8E48). 
+This native is used along with these two natives: [`TERRAINGRID_ACTIVATE`](#_0xA356990E161C9E65) and [`TERRAINGRID_SET_PARAMS`](#_0x1C4FC5752BCD8E48). 
 This native sets the colors for the golf putting grid. the 'min...' values are for the lower areas that the grid covers, the 'max...' values are for the higher areas that the grid covers, all remaining values are for the 'normal' ground height.
 All those natives combined they will output something like this: https://i.imgur.com/TC6cku6.png
 

--- a/GRAPHICS/TerraingridSetParams.md
+++ b/GRAPHICS/TerraingridSetParams.md
@@ -9,7 +9,7 @@ aliases: ["0x1C4FC5752BCD8E48"]
 void TERRAINGRID_SET_PARAMS(float x, float y, float z, float p3, float rotation, float p5, float width, float height, float p8, float scale, float glowIntensity, float normalHeight, float heightDiff);
 ```
 
-This native is used along with these two natives: [`0xa356990e161c9e65`](https://runtime.fivem.net/doc/reference.html#_0xA356990E161C9E65) and [`0x5ce62918f8d703c7`](https://runtime.fivem.net/doc/reference.html#_0x5CE62918F8D703C7). 
+This native is used along with these two natives: [`TERRAINGRID_ACTIVATE`](#_0xA356990E161C9E65) and [`TERRAINGRID_SET_COLOURS`](#_0x5CE62918F8D703C7).
 
 This native configures the location, size, rotation, normal height, and the difference ratio between min, normal and max.
 

--- a/HUD/ClearGpsMultiRoute.md
+++ b/HUD/ClearGpsMultiRoute.md
@@ -9,4 +9,4 @@ aliases: ["0x67EEDEA1B9BAFD94"]
 void CLEAR_GPS_MULTI_ROUTE();
 ```
 
-Does the same as [`SET_GPS_MULTI_ROUTE_RENDER(false)`](https://runtime.fivem.net/doc/reference.html#_0x3DDA37128DD1ACA8)
+Does the same as [`SET_GPS_MULTI_ROUTE_RENDER(false)`](#_0x3DDA37128DD1ACA8)

--- a/HUD/GivePedToPauseMenu.md
+++ b/HUD/GivePedToPauseMenu.md
@@ -13,7 +13,7 @@ p1 is either 1 or 2 in the PC scripts.
 ```
 
 
-This native is used to "give"/duplicate a player ped to a frontend menu as configured via the `ACTIVATE_FRONTEND_MENU` native, you first must utilize the `CLONE_PED` ( https://runtime.fivem.net/doc/natives/#_0xEF29A16337FACADB ) to clone said ped.
+This native is used to "give"/duplicate a player ped to a frontend menu as configured via the `ACTIVATE_FRONTEND_MENU` native, you first must utilize the [CLONE_PED](#_0xEF29A16337FACADB) to clone said ped.
 
 
 ## Parameters

--- a/HUD/SetBlipSprite.md
+++ b/HUD/SetBlipSprite.md
@@ -8,10 +8,6 @@ ns: HUD
 void SET_BLIP_SPRITE(Blip blip, int spriteId);
 ```
 
-<!--
-_loc1_.map((name, idx) => `| ${idx} | ${name} | ![${name}](https://runtime.fivem.net/blips/${name}.svg) |`).join('\n')
--->
-
 Sets the displayed sprite for a specific blip.
 
 There's a [list of sprites](https://docs.fivem.net/game-references/blips/) on the FiveM documentation site.

--- a/HUD/SetMinimapGolfCourse.md
+++ b/HUD/SetMinimapGolfCourse.md
@@ -16,7 +16,7 @@ All I know for sure is that it draws the specified hole ID on the pause menu map
 You need to center the minimap manually as well as change/lock it's zoom and angle in order for it to appear correctly on the minimap.
 You'll also need to use the `GOLF` scaleform in order to get the correct minmap border to show up.
 
-Use [`N_0x35edd5b2e3ff01c0()`](https://runtime.fivem.net/doc/reference.html#_0x35EDD5B2E3FF01C0) to reset the map when you no longer want to display any golf holes (you still need to unlock zoom, position and angle of the radar manually after calling this).
+Use [`SET_MINIMAP_GOLF_COURSE_OFF()`](#_0x35EDD5B2E3FF01C0) to reset the map when you no longer want to display any golf holes (you still need to unlock zoom, position and angle of the radar manually after calling this).
 
 ## Parameters
 * **hole**: The ID of the hole to draw on the map. ID starts with 1 for hole 1, 2 for hole 2, etc. 0 disables the golf map behaviour.

--- a/WEAPON/SetCanPedEquipAllWeapons.md
+++ b/WEAPON/SetCanPedEquipAllWeapons.md
@@ -9,7 +9,7 @@ aliases: ["0xEFF296097FF1E509"]
 void _SET_CAN_PED_EQUIP_ALL_WEAPONS(Ped ped, BOOL toggle);
 ```
 
-Does the same as [`_SET_CAN_PED_SELECT_WEAPON`](https://runtime.fivem.net/doc/natives/#_0xB4771B9AAF4E68E4) except for all weapons.
+Does the same as [`_SET_CAN_PED_SELECT_WEAPON`](#_0xB4771B9AAF4E68E4) except for all weapons.
 
 
 ## Parameters


### PR DESCRIPTION
This PR fixes all the remaining old runtime.fivem.net links in the natives description and also renames some natives in the description as they got a name after their documentation creation
