### PR TITLE
fix: Flag for `StartShapeTestLosProbe`

### DIFF
--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -17,11 +17,12 @@ enum TraceFlags
   None = 0,
   IntersectWorld = 1,
   IntersectVehicles = 2,
-  IntersectPedsSimpleCollision = 4,
-  IntersectPeds = 8,
+  IntersectPeds = 4,
+  IntersectRagdoll = 8,
   IntersectObjects = 16,
   IntersectWater = 32,
-  Unknown = 128,
+  IntersectGlass = 64,
+  IntersectRiver = 128,
   IntersectFoliage = 256,
   IntersectEverything = -1
 }

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -23,7 +23,6 @@ enum TraceFlags
   IntersectWater = 32,
   Unknown = 128,
   IntersectFoliage = 256,
-  IntersectEverything = 511
   IntersectEverything = -1
 }
 ```

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -23,8 +23,8 @@ enum TraceFlags
   IntersectWater = 32,
   Unknown = 128,
   IntersectFoliage = 256,
-  Unkown = 511, (used most)
-  IntersectEverything = 4294967295
+  IntersectEverything = 511
+  IntersectEverything = -1
 }
 ```
 NOTE: Raycasts that intersect with mission_entites (flag = 2) has limited range and will not register for far away entites. The range seems to be about 30 metres.  

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -24,7 +24,7 @@ enum TraceFlags
   IntersectGlass = 64,
   IntersectRiver = 128,
   IntersectFoliage = 256,
-  IntersectEverything = -1
+  IntersectAll = 511
 }
 ```
 NOTE: Raycasts that intersect with mission_entites (flag = 2) has limited range and will not register for far away entites. The range seems to be about 30 metres.  

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -23,6 +23,7 @@ enum TraceFlags
   IntersectWater = 32,
   Unknown = 128,
   IntersectFoliage = 256,
+  Unkown = 511, (used most)
   IntersectEverything = 4294967295
 }
 ```

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -6,7 +6,7 @@ aliases: ["0x7EE9F5D83DD4F90E"]
 
 ```c
 // 0x7EE9F5D83DD4F90E 0xEFAF4BA6
-int START_SHAPE_TEST_LOS_PROBE(float x1, float y1, float z1, float x2, float y2, float z2, int flags, Entity entity, int p8);
+int START_SHAPE_TEST_LOS_PROBE(float x1, float y1, float z1, float x2, float y2, float z2, int flags, Entity entity, int options);
 ```
 
 Asynchronously starts a line-of-sight (raycast) world probe shape test.

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -18,7 +18,7 @@ enum TraceFlags
   IntersectWorld = 1,
   IntersectVehicles = 2,
   IntersectPeds = 4,
-  IntersectRagdoll = 8,
+  IntersectRagdolls = 8,
   IntersectObjects = 16,
   IntersectWater = 32,
   IntersectGlass = 64,
@@ -41,7 +41,7 @@ Use the handle with [GET_SHAPE_TEST_RESULT](#_0x3D87450E15D98694) or [GET_SHAPE_
 * **z2**: Ending Z coordinate.
 * **flags**: Flags.
 * **entity**: An entity to ignore, or 0.
-* **p8**: A bit mask with bits 1, 2, 4, or 7 relating to collider types. 4 and 7 are usually used.
+* **options**: A bit mask with bits 1, 2, 4, or 7 relating to collider types. 4 and 7 are usually used.
 
 ## Return value
 A shape test handle.

--- a/SHAPETEST/StartShapeTestLosProbe.md
+++ b/SHAPETEST/StartShapeTestLosProbe.md
@@ -24,7 +24,7 @@ enum TraceFlags
   IntersectGlass = 64,
   IntersectRiver = 128,
   IntersectFoliage = 256,
-  IntersectAll = 511
+  IntersectEverything = -1
 }
 ```
 NOTE: Raycasts that intersect with mission_entites (flag = 2) has limited range and will not register for far away entites. The range seems to be about 30 metres.  


### PR DESCRIPTION
~~Found that the flag 511 is used the most in decompiled scripts~~

Fixed a flag...