### PR TITLE
Update SetWantedLevel Natives p3

### DIFF
--- a/PLAYER/SetPlayerWantedLevel.md
+++ b/PLAYER/SetPlayerWantedLevel.md
@@ -11,7 +11,7 @@ void SET_PLAYER_WANTED_LEVEL(Player player, int wantedLevel, BOOL delayedRespons
 ## Parameters
 * **player**: the target player
 * **wantedLevel**: the wanted level 1-5
-* **delayedResponse**: false = 0-5sec police spawn response time, true = 10-20sec police spawn response time
+* **delayedResponse**: false = 0-10sec police spawn response time, true = 10-20sec police spawn response time
 
 ## Examples
 ```lua

--- a/PLAYER/SetPlayerWantedLevel.md
+++ b/PLAYER/SetPlayerWantedLevel.md
@@ -5,17 +5,16 @@ ns: PLAYER
 
 ```c
 // 0x39FF19C64EF7DA5B 0xB7A0914B
-void SET_PLAYER_WANTED_LEVEL(Player player, int wantedLevel, BOOL disableNoMission);
-```
-
-```
-Call SET_PLAYER_WANTED_LEVEL_NOW for immediate effect  
-wantedLevel is an integer value representing 0 to 5 stars even though the game supports the 6th wanted level but no police will appear since no definitions are present for it in the game files  
-disableNoMission-  Disables When Off Mission- appears to always be false  
+void SET_PLAYER_WANTED_LEVEL(Player player, int wantedLevel, BOOL delayedResponse);
 ```
 
 ## Parameters
-* **player**: 
-* **wantedLevel**: 
-* **disableNoMission**: 
+* **player**: the target player
+* **wantedLevel**: the wanted level 1-5
+* **delayedResponse**: false = 0-5sec police spawn response time, true = 10-20sec police spawn response time
 
+## Examples
+```lua
+local player = PlayerId()
+SetPlayerWantedLevel(player, 5, false) -- 5 star wanted level
+```

--- a/PLAYER/SetPlayerWantedLevelNoDrop.md
+++ b/PLAYER/SetPlayerWantedLevelNoDrop.md
@@ -11,7 +11,7 @@ void SET_PLAYER_WANTED_LEVEL_NO_DROP(Player player, int wantedLevel, BOOL delaye
 ## Parameters
 * **player**: the target player
 * **wantedLevel**: the wanted level 1-5
-* **delayedResponse**: false = 0-5sec police spawn response time, true = 10-20sec police spawn response time
+* **delayedResponse**: false = 0-10sec police spawn response time, true = 10-20sec police spawn response time
 
 ## Examples
 ```lua

--- a/PLAYER/SetPlayerWantedLevelNoDrop.md
+++ b/PLAYER/SetPlayerWantedLevelNoDrop.md
@@ -5,15 +5,16 @@ ns: PLAYER
 
 ```c
 // 0x340E61DE7F471565 0xED6F44F5
-void SET_PLAYER_WANTED_LEVEL_NO_DROP(Player player, int wantedLevel, BOOL p2);
-```
-
-```
-p2 is always false in R* scripts  
+void SET_PLAYER_WANTED_LEVEL_NO_DROP(Player player, int wantedLevel, BOOL delayedResponse);
 ```
 
 ## Parameters
-* **player**: 
-* **wantedLevel**: 
-* **p2**: 
+* **player**: the target player
+* **wantedLevel**: the wanted level 1-5
+* **delayedResponse**: false = 0-5sec police spawn response time, true = 10-20sec police spawn response time
 
+## Examples
+```lua
+local player = PlayerId()
+SetPlayerWantedLevelNoDrop(player, 5, false) -- 5 star wanted level
+```


### PR DESCRIPTION
I done some tests to figure out what p3 does for SetPlayerWantedLevelNoDrop and found that its a delay for the police spawn response time

its the same for both
[SetPlayerWantedLevelNoDrop](https://docs.fivem.net/natives/?_0x340E61DE7F471565)
[SetPlayerWantedLevel](https://docs.fivem.net/natives/?_0x39FF19C64EF7DA5B)

`delayedResponse false`

https://github.com/citizenfx/natives/assets/100861025/31a001b1-a3fd-4eab-9693-cea71768e35b

`delayedResponse true`

https://github.com/citizenfx/natives/assets/100861025/d1df27f5-e354-4d4d-9d43-3301e0ce1658


here is the code i used to figure this out
```lua
RegisterCommand('setWanted', function(source, args)
    local player = PlayerId()
    local coords = GetEntityCoords(PlayerPedId())
    ClearArea(coords, 300.0, 0, 0, 0, 0)
    ClearPlayerWantedLevel(player) 
    local startTime = GetGameTimer()
    SetPlayerWantedLevelNoDrop(player, 1, true) -- setting this to true/false
    while GetPlayerWantedLevel(player) == 0 do
        Wait(0)
    end
    local ms = GetGameTimer() - startTime
    print("Time taken to get wanted level: "..ms.." ms")

    local startTime = GetGameTimer()
    local policeVehicle = false
    while not policeVehicle do
        Wait(0)
        local vehiclePool = GetGamePool('CVehicle') 
        for i = 1, #vehiclePool do 
            if GetEntityModel(vehiclePool[i]) == (`police3` or `police` or `police2` or `riot`) then
                print('got police')
                policeVehicle = true
            end
        end
    end
    local ms = GetGameTimer() - startTime
    print("Time taken to get first police vehicle: "..ms.." ms")
end)
```

