### PR TITLE
Update SetParticleFxLoopedColour.md

### DIFF
--- a/GRAPHICS/SetParticleFxLoopedColour.md
+++ b/GRAPHICS/SetParticleFxLoopedColour.md
@@ -17,4 +17,4 @@ You can use the [inverse lerp](https://www.gamedev.net/articles/programming/gene
 * **r**: range from 0.0 to 1.0
 * **g**: range from 0.0 to 1.0
 * **b**: range from 0.0 to 1.0
-* **bLocalOnly**: Defines whether the effect should be modified over the network or not. Set this to false if you want to apply the effect over the network.
+* **bLocalOnly**: False by default. Defines whether the effect should be sent and modified over the network or not. Set this to `true` if you don't want to send the effect over the network.

--- a/GRAPHICS/SetParticleFxLoopedColour.md
+++ b/GRAPHICS/SetParticleFxLoopedColour.md
@@ -8,15 +8,15 @@ ns: GRAPHICS
 void SET_PARTICLE_FX_LOOPED_COLOUR(int ptfxHandle, float r, float g, float b, BOOL p4);
 ```
 
-```
-only works on some fx's  
-p4 = 0  
-```
-
 ## Parameters
 * **ptfxHandle**: 
-* **r**: 
-* **g**: 
-* **b**: 
+* **r**: range from 0.0 to 1.0
+* **g**: range from 0.0 to 1.0
+* **b**: range from 0.0 to 1.0
 * **p4**: 
 
+
+only works on some fx's  
+p4 = 0
+
+You can use the [inverse lerp](https://www.gamedev.net/articles/programming/general-and-gameplay-programming/inverse-lerp-a-super-useful-yet-often-overlooked-function-r5230/) method to normalize in a range from 0.0 to 1.0 an rgb

--- a/GRAPHICS/SetParticleFxLoopedColour.md
+++ b/GRAPHICS/SetParticleFxLoopedColour.md
@@ -5,18 +5,16 @@ ns: GRAPHICS
 
 ```c
 // 0x7F8F65877F88783B 0x5219D530
-void SET_PARTICLE_FX_LOOPED_COLOUR(int ptfxHandle, float r, float g, float b, BOOL p4);
+void SET_PARTICLE_FX_LOOPED_COLOUR(int ptfxHandle, float r, float g, float b, BOOL bLocalOnly);
 ```
+
+Sets the colour tint of a previously started looped particle effect
+
+You can use the [inverse lerp](https://www.gamedev.net/articles/programming/general-and-gameplay-programming/inverse-lerp-a-super-useful-yet-often-overlooked-function-r5230/) method to normalize in a range from 0.0 to 1.0 an rgb
 
 ## Parameters
 * **ptfxHandle**: 
 * **r**: range from 0.0 to 1.0
 * **g**: range from 0.0 to 1.0
 * **b**: range from 0.0 to 1.0
-* **p4**: 
-
-
-only works on some fx's  
-p4 = 0
-
-You can use the [inverse lerp](https://www.gamedev.net/articles/programming/general-and-gameplay-programming/inverse-lerp-a-super-useful-yet-often-overlooked-function-r5230/) method to normalize in a range from 0.0 to 1.0 an rgb
+* **bLocalOnly**: Defines whether the effect should be modified over the network or not. Set this to false if you want to apply the effect over the network.


### PR DESCRIPTION
added a more precise description for color ranges and also a tip on how to convert an rgb to the necessary range.
for the external link it would be better to find a method to make it "permanent" i read the advice to add it to the fivem documentation but idk where to put it