### PR TITLE
Update GetGroundZFor_3dCoord.md

### DIFF
--- a/MISC/GetGroundZFor_3dCoord.md
+++ b/MISC/GetGroundZFor_3dCoord.md
@@ -5,22 +5,32 @@ ns: MISC
 
 ```c
 // 0xC906A7DAB05C8D2B 0xA1BFD5E0
-BOOL GET_GROUND_Z_FOR_3D_COORD(float x, float y, float z, float* groundZ, BOOL ignoreWater);
+BOOL GET_GROUND_Z_FOR_3D_COORD(float x, float y, float z, float* groundZ, BOOL includeWater);
 ```
 
-```
-Bear in mind this native can only calculate the elevation when the coordinates are within the client's render distance.
-```
+This native gets the ground level (ground elevation) and returns the Z coordinate that represents it.
+Note: This native can only calculate the elevation when the coordinates are within the render distance of the client.
 
 ```
 NativeDB Added Parameter 6: BOOL p5
 ```
 
 ## Parameters
-* **x**: Position on the X-axis to get ground elevation at.
-* **y**: Position on the Y-axis to get ground elevation at.
-* **z**: Position on the Z-axis to get ground elevation at.
-* **groundZ**: The ground elevation at the specified position.
-* **ignoreWater**: 
+* **x**: Position on the X-axis to get ground elevation.
+* **y**: Position on the Y-axis to get ground elevation.
+* **z**: Position on the Z-axis to get ground elevation.
+* **includeWater**: Determines if the top water level at the specified position should be considered the ground elevation. (It would only matter if the specified position is located above or under the water)
 
 ## Return value
+This native`s first return value (retval) will return true if the ground elevation has been found, and the second (groundZ) will return the z-coord which represents the ground elevation at the specified position.
+
+## Examples
+```lua
+local ped = PlayerPedId()
+local pedCoords = GetEntityCoords(ped) 
+local retval, groundZ = GetGroundZFor_3dCoord(pedCoords.x, pedCoords.y, pedCoords.z, true)
+
+if retval then
+   -- Do stuff with groundZ
+end
+```


### PR DESCRIPTION
Just an overall cleanup of this specific native's docs page and a change of its 4th parameter that was wrongly named.

"ignoreWater" suggests that the parameter is a toggle for ignoring the water, whilst when setting it to true, the top water level becomes the ground level returned by the native.

Test:
```lua
local ped = PlayerPedId()
local pedCoords = GetEntityCoords(ped) 
local retval, groundZ = GetGroundZFor_3dCoord(pedCoords.x, pedCoords.y, pedCoords.z, true)
local retval2, groundZ2 = GetGroundZFor_3dCoord(pedCoords.x, pedCoords.y, pedCoords.z, false)
print(groundZ, groundZ2) -- 0.0 -0.83195984363555
```

1. Set the player ped into the water
2. Run the snippet.
3. Compare the results and notice that the result with the parameter set to true is greater than the result with the parameter set to false.

The larger result of the two represents the top water level, and the smaller result represents the bottom water level.
Therefore the 4th parameter should be considered to include the water.