### PR TITLE
Update AttachCamToPedBone.md

### DIFF
--- a/CAM/AttachCamToPedBone.md
+++ b/CAM/AttachCamToPedBone.md
@@ -5,7 +5,7 @@ ns: CAM
 
 ```c
 // 0x61A3DBA14AB7F411 0x506BB35C
-void ATTACH_CAM_TO_PED_BONE(Cam cam, Ped ped, int boneIndex, float xOffset, float yOffset, float zOffset, BOOL isRelative);
+void ATTACH_CAM_TO_PED_BONE(Cam cam, Ped ped, int boneId, float xOffset, float yOffset, float zOffset, BOOL isRelative);
 ```
 
 

--- a/CAM/AttachCamToPedBone.md
+++ b/CAM/AttachCamToPedBone.md
@@ -12,7 +12,7 @@ void ATTACH_CAM_TO_PED_BONE(Cam cam, Ped ped, int boneIndex, float xOffset, floa
 ## Parameters
 * **cam**: 
 * **ped**: 
-* **boneIndex**: 
+* **boneId**: 
 * **xOffset**: 
 * **yOffset**: 
 * **zOffset**: 


### PR DESCRIPTION
As can be seen in GTA source code:
```cpp
			Var0 = { PED::GET_PED_BONE_COORDS(PLAYER::PLAYER_PED_ID(), 31086, 0f, -0.25f, 0f) };
			func_116(&Local_325, Var0, ENTITY::GET_ENTITY_ROTATION(PLAYER::PLAYER_PED_ID(), 2), 50f, Local_325.f_20, Local_325.f_21, 3, 1101004800, 0, 0, -1082130432, 0);
			CAM::ATTACH_CAM_TO_PED_BONE(Local_325.f_0, PLAYER::PLAYER_PED_ID(), 31086, 0f, -0.25f, 0f, true);
```

The bone parameter here is a boneId and not a boneIndex.