### PR TITLE
Add proper description for IsEntityOnScreen

### DIFF
--- a/ENTITY/IsEntityOnScreen.md
+++ b/ENTITY/IsEntityOnScreen.md
@@ -12,5 +12,9 @@ Determines whether the screen position of the specified entity is within the 2D 
 
 This native will not check if the entity is not visible due to being occluded (for example, behind a wall). To check if a entity is on screen and is not occluded, use [IS_ENTITY_OCCLUDED](#_0xE31C2C72B8692B64).
 
+## Return value
+
+Returns `true` if the the entity is in between the minimum and maximum values for the 2d screen coord; otherwise, `false`.
+
 ## Parameters
 * **entity**: The entity to check.

--- a/ENTITY/IsEntityOnScreen.md
+++ b/ENTITY/IsEntityOnScreen.md
@@ -8,13 +8,9 @@ ns: ENTITY
 BOOL IS_ENTITY_ON_SCREEN(Entity entity);
 ```
 
-```
-Returns true if the entity is in between the minimum and maximum values for the 2d screen coords.   
-This means that it will return true even if the entity is behind a wall for example, as long as you're looking at their location.   
-Chipping  
-```
+Determines whether the screen position of the specified entity is within the 2D bounds of the screen.
+
+This native will not check if the entity is not visible due to being occluded (for example, behind a wall). To check if a entity is on screen and is not occluded, use [IS_ENTITY_OCCLUDED](#_0xE31C2C72B8692B64).
 
 ## Parameters
-* **entity**: 
-
-## Return value
+* **entity**: The entity to check.

--- a/ENTITY/IsEntityOnScreen.md
+++ b/ENTITY/IsEntityOnScreen.md
@@ -16,4 +16,4 @@ This native will not check if the entity is not visible due to being occluded (f
 * **entity**: The entity to check.
 
 ## Return value
-Returns `true` if the the entity is in between the minimum and maximum values for the 2d screen coord; otherwise, `false`.
+Returns `true` if the the entity is in between the minimum and maximum values for the 2D screen bound coords (X, Y); otherwise, `false`.

--- a/ENTITY/IsEntityOnScreen.md
+++ b/ENTITY/IsEntityOnScreen.md
@@ -16,4 +16,4 @@ This native will not check if the entity is not visible due to being occluded (f
 * **entity**: The entity to check.
 
 ## Return value
-Returns `true` if the the entity is in between the minimum and maximum values for the 2D screen bound coords (X, Y); otherwise, `false`.
+Returns `true` if the the entity is in between the minimum and maximum values for the 2D screen bound coords; otherwise, `false`.

--- a/ENTITY/IsEntityOnScreen.md
+++ b/ENTITY/IsEntityOnScreen.md
@@ -12,9 +12,8 @@ Determines whether the screen position of the specified entity is within the 2D 
 
 This native will not check if the entity is not visible due to being occluded (for example, behind a wall). To check if a entity is on screen and is not occluded, use [IS_ENTITY_OCCLUDED](#_0xE31C2C72B8692B64).
 
-## Return value
-
-Returns `true` if the the entity is in between the minimum and maximum values for the 2d screen coord; otherwise, `false`.
-
 ## Parameters
 * **entity**: The entity to check.
+
+## Return value
+Returns `true` if the the entity is in between the minimum and maximum values for the 2d screen coord; otherwise, `false`.


### PR DESCRIPTION
Adds a properly formatted description for `IsEntityOnScreen`.

I do not consider an example would be needed for this native considering how simple is the native is, and the new description means about the same thing as of the old imported description.

Feel free to edit this PR if you think something is wrong.