### PR TITLE
Update StopGameplayCamShaking.md

### DIFF
--- a/CAM/StopGameplayCamShaking.md
+++ b/CAM/StopGameplayCamShaking.md
@@ -5,10 +5,9 @@ ns: CAM
 
 ```c
 // 0x0EF93E9F3D08C178 0xFD569E4E
-void STOP_GAMEPLAY_CAM_SHAKING(BOOL bstopImmediately);
+void STOP_GAMEPLAY_CAM_SHAKING(BOOL bStopImmediately);
 ```
 
-
 ## Parameters
-* **bstopImmediately**: Should the shake stop this frame.
+* **bStopImmediately**: Should the shake stop this frame.
 

--- a/CAM/StopGameplayCamShaking.md
+++ b/CAM/StopGameplayCamShaking.md
@@ -5,10 +5,10 @@ ns: CAM
 
 ```c
 // 0x0EF93E9F3D08C178 0xFD569E4E
-void STOP_GAMEPLAY_CAM_SHAKING(BOOL stopImmediately);
+void STOP_GAMEPLAY_CAM_SHAKING(BOOL bstopImmediately);
 ```
 
 
 ## Parameters
-* **stopImmediately**: Should the shake stop this frame?
+* **bstopImmediately**: Should the shake stop this frame.
 

--- a/CAM/StopGameplayCamShaking.md
+++ b/CAM/StopGameplayCamShaking.md
@@ -5,10 +5,10 @@ ns: CAM
 
 ```c
 // 0x0EF93E9F3D08C178 0xFD569E4E
-void STOP_GAMEPLAY_CAM_SHAKING(BOOL p0);
+void STOP_GAMEPLAY_CAM_SHAKING(BOOL stopImmediately);
 ```
 
 
 ## Parameters
-* **p0**: 
+* **stopImmediately**: Should the shake stop this frame?
 


### PR DESCRIPTION
Tested in a server and found the boolean parameter would stop shaking the frame it was called on, instead of slowing the shake to a stop.

Before you submit this PR, please make sure:

- You have read the contribution guidelines
- You include an example that validates your change
- Your English is grammatically correct
