### PR TITLE
fix: few cutscene links

### DIFF
--- a/CUTSCENE/GetCutsceneEndTime.md
+++ b/CUTSCENE/GetCutsceneEndTime.md
@@ -9,7 +9,7 @@ aliases: ['0x971D7B15BCDBEF99']
 int _GET_CUTSCENE_END_TIME();
 ```
 
-Returns the time of the cutscene's end accounting for [`REQUEST_CUTSCENE_WITH_PLAYBACK_LIST`](_0xC23DE0E91C30B58C) 
+Returns the time of the cutscene's end accounting for [`REQUEST_CUTSCENE_WITH_PLAYBACK_LIST`](#_0xC23DE0E91C30B58C) 
 
 If a cutscene is laid out with 10 second sections, and section 0 and 1 are enabled then it would be 20000ms.
 

--- a/CUTSCENE/GetCutsceneTotalDuration.md
+++ b/CUTSCENE/GetCutsceneTotalDuration.md
@@ -9,7 +9,7 @@ int GET_CUTSCENE_TOTAL_DURATION();
 ```
 
 Gets the total length of the cutscene irrespective of playback list in milliseconds
-To account for sections, see [`_GET_CUTSCENE_END_TIME`]()
+To account for sections, see [`_GET_CUTSCENE_END_TIME`](#_0x971D7B15BCDBEF99)
 
 ## Return value
 Cutscene total length in milliseconds

--- a/CUTSCENE/SetCutscenePedPropVariation.md
+++ b/CUTSCENE/SetCutscenePedPropVariation.md
@@ -9,7 +9,7 @@ aliases: ["0x0546524ADE2E9723"]
 void SET_CUTSCENE_PED_PROP_VARIATION(char* cutsceneEntName, int componentId, int drawableId, int textureId, Hash modelHash);
 ```
 
-See [`SET_PED_PROP_INDEX`](_0x93376B65A266EB5F)
+See [`SET_PED_PROP_INDEX`](#_0x93376B65A266EB5F)
 
 ## Parameters
 * **cutsceneEntName**: i.e Michael, Trevor, MP_1, MP_4

--- a/CUTSCENE/StartCutsceneAtCoords.md
+++ b/CUTSCENE/StartCutsceneAtCoords.md
@@ -8,7 +8,7 @@ ns: CUTSCENE
 void START_CUTSCENE_AT_COORDS(float x, float y, float z, int flags);
 ```
 
-Similar to [`SET_CUTSCENE_ORIGIN`](_0xB812B3FD1C01CF27) but without heading and doesn't need [`START_CUTSCENE`](_0x186D5CB5E7B0FF7B)
+Similar to [`SET_CUTSCENE_ORIGIN`](#_0xB812B3FD1C01CF27) but without heading and doesn't need [`START_CUTSCENE`](#_0x186D5CB5E7B0FF7B)
 
 ## Parameters
 * **x**: 


### PR DESCRIPTION
Related to: https://github.com/citizenfx/fivem/pull/2378. 

The hash to `0x011883F41211432A` was also lowercase while all other natives use uppercase.