### PR TITLE
Restore dead Imgur links

### DIFF
--- a/CAM/SetCamSplineSmoothingStyle.md
+++ b/CAM/SetCamSplineSmoothingStyle.md
@@ -49,7 +49,7 @@ Using 1-3 will result in misalignment from the passed durations for the spline n
 
 Graph below demonstrates interpolation between 0-1000 and back 10 times.
 
-![](https://i.imgur.com/cixWh7m.png)
+![](https://i.imgur.com/Lj97T3F.png)
 
 ## Parameters
 * **cam**: The DEFAULT_SPLINE_CAMERA to apply the smoothing to

--- a/GRAPHICS/TerraingridActivate.md
+++ b/GRAPHICS/TerraingridActivate.md
@@ -9,7 +9,7 @@ aliases: ["0xA356990E161C9E65"]
 void TERRAINGRID_ACTIVATE(BOOL toggle);
 ```
 
-This native enables/disables the gold putting grid display (https://i.imgur.com/TC6cku6.png).
+This native enables/disables the gold putting grid display (https://i.imgur.com/WXeg95i.png).
 This requires these two natives to be called as well to configure the grid: [`TERRAINGRID_SET_PARAMS`](#_0x1C4FC5752BCD8E48) and [`TERRAINGRID_SET_COLOURS`](#_0x5CE62918F8D703C7).
 
 

--- a/GRAPHICS/TerraingridSetColours.md
+++ b/GRAPHICS/TerraingridSetColours.md
@@ -12,7 +12,7 @@ void TERRAINGRID_SET_COLOURS(int lowR, int lowG, int lowB, int lowAlpha, int R, 
 
 This native is used along with these two natives: [`TERRAINGRID_ACTIVATE`](#_0xA356990E161C9E65) and [`TERRAINGRID_SET_PARAMS`](#_0x1C4FC5752BCD8E48). 
 This native sets the colors for the golf putting grid. the 'min...' values are for the lower areas that the grid covers, the 'max...' values are for the higher areas that the grid covers, all remaining values are for the 'normal' ground height.
-All those natives combined they will output something like this: https://i.imgur.com/TC6cku6.png
+All those natives combined they will output something like this: https://i.imgur.com/WXeg95i.png
 
 Old description:
 Only called in golf and golf_mp  

--- a/GRAPHICS/TerraingridSetParams.md
+++ b/GRAPHICS/TerraingridSetParams.md
@@ -13,7 +13,7 @@ This native is used along with these two natives: [`TERRAINGRID_ACTIVATE`](#_0xA
 
 This native configures the location, size, rotation, normal height, and the difference ratio between min, normal and max.
 
-All those natives combined they will output something like this: https://i.imgur.com/TC6cku6.png
+All those natives combined they will output something like this: https://i.imgur.com/WXeg95i.png
 
 ## Parameters
 * **x**: Grid center x coord.

--- a/HUD/AddBlipForEntity.md
+++ b/HUD/AddBlipForEntity.md
@@ -12,9 +12,9 @@ Create a blip that by default is red (enemy), you can use [SET_BLIP_AS_FRIENDLY]
 Can be used for objects, vehicles and peds.
 
 Example of enemy:
-![enemy](https://i.imgur.com/fl78svv.png)
+![enemy](https://i.imgur.com/1agTGTa.png)
 Example of friend:
-![friend](https://i.imgur.com/Q16ho5d.png)
+![friend](https://i.imgur.com/uHpLos3.png)
 
 ## Parameters
 * **entity**: The entity handle to create the blip.

--- a/HUD/AddBlipForRadius.md
+++ b/HUD/AddBlipForRadius.md
@@ -10,7 +10,7 @@ Blip ADD_BLIP_FOR_RADIUS(float posX, float posY, float posZ, float radius);
 Create a blip with a radius for the specified coordinates (it doesnt create the blip sprite, so you need to use [AddBlipCoords](#_0xC6F43D0E))
 
 Example image:
-![example](https://i.imgur.com/9hQl3DB.png)
+![example](https://i.imgur.com/PYjCapV.png)
 
 ## Parameters
 * **posX**: The x position of the blip (you can also send a vector3 instead of the bulk coordinates)

--- a/HUD/DisplayPlayerNameTagsOnBlips.md
+++ b/HUD/DisplayPlayerNameTagsOnBlips.md
@@ -11,7 +11,7 @@ void DISPLAY_PLAYER_NAME_TAGS_ON_BLIPS(BOOL toggle);
 
 Toggles whether or not name labels are shown on the expanded minimap next to player blips, like in GTA:O.
 Doesn't need to be called every frame.
-Preview: https://i.imgur.com/DfqKWfJ.png
+Preview: https://i.imgur.com/jAglStg.png
 Make sure to call SET_BLIP_CATEGORY with index 7 for this to work on the desired blip.
 
 ## Parameters

--- a/HUD/EndTextCommandThefeedPostAward.md
+++ b/HUD/EndTextCommandThefeedPostAward.md
@@ -11,7 +11,7 @@ int END_TEXT_COMMAND_THEFEED_POST_AWARD(char* textureDict, char* textureName, in
 
 Shows an "award" notification above the minimap, lua example result:
 
-![](https://i.imgur.com/e2DNaKX.png)
+![](https://i.imgur.com/DYB5qo5.png)
 
 
 

--- a/HUD/EndTextCommandThefeedPostMessagetext.md
+++ b/HUD/EndTextCommandThefeedPostMessagetext.md
@@ -15,7 +15,7 @@ Texture dictionary and texture name parameters are usually the same exact value.
 
 Example result:
 
-![](https://i.imgur.com/LviutDl.png)
+![](https://i.imgur.com/RrZthgE.png)
 
 Old description with list of possible icons and texture names:
 

--- a/HUD/EndTextCommandThefeedPostMessagetextTu.md
+++ b/HUD/EndTextCommandThefeedPostMessagetextTu.md
@@ -16,7 +16,7 @@ v_8 = UI::END_TEXT_COMMAND_THEFEED_POST_MESSAGETEXT_TU("CHAR_SOCIAL_CLUB", "CHAR
 ```
 
 Example result:
-![](https://i.imgur.com/YrN4Bcm.png)
+![](https://i.imgur.com/DybiVQM.png)
 
 
 ## Parameters

--- a/HUD/EndTextCommandThefeedPostStats.md
+++ b/HUD/EndTextCommandThefeedPostStats.md
@@ -15,7 +15,7 @@ int END_TEXT_COMMAND_THEFEED_POST_STATS(char* statTitle, int iconEnum, BOOL step
 Example result:
 
 
-![](https://i.imgur.com/SdEZ22m.png)
+![](https://i.imgur.com/LCHQpjg.png)
 
 
 ## Parameters

--- a/HUD/EndTextCommandThefeedPostTicker.md
+++ b/HUD/EndTextCommandThefeedPostTicker.md
@@ -12,7 +12,7 @@ int END_TEXT_COMMAND_THEFEED_POST_TICKER(BOOL isImportant, BOOL bHasTokens);
 Example output preview:
 
 
-![](https://i.imgur.com/TJvqkYq.png)
+![](https://i.imgur.com/jpUdMTP.png)
 
 
 ## Examples

--- a/HUD/PauseMenuSetWarnOnTabChange.md
+++ b/HUD/PauseMenuSetWarnOnTabChange.md
@@ -9,7 +9,7 @@ aliases: ["0xF06EBB91A81E09E3"]
 void PAUSE_MENU_SET_WARN_ON_TAB_CHANGE(BOOL setWarn);
 ```
 
-Shows this warning message when trying to switch pause menu header tabs: https://i.imgur.com/8qmfztu.png
+Shows this warning message when trying to switch pause menu header tabs: https://i.imgur.com/4PbjPcs.png
 
 ## Parameters
 * **setWarn**: Wether to show the message or not.

--- a/HUD/SetBlipCategory.md
+++ b/HUD/SetBlipCategory.md
@@ -10,7 +10,7 @@ void SET_BLIP_CATEGORY(Blip blip, int index);
 
 Examples result:
 
-![](https://i.imgur.com/skY6vAJ.png)
+![](https://i.imgur.com/3ralFxl.png)
 
 
 **index:**

--- a/HUD/SetMinimapGolfCourse.md
+++ b/HUD/SetMinimapGolfCourse.md
@@ -37,6 +37,6 @@ SetRadarBigmapEnabled(false, false);
 int blip = AddBlipForCoord(-1321.98f, 158.93f, 57.8f);
 SetBlipSprite(blip, 358);
 
-// result of this code example: https://i.imgur.com/DUnUzKS.png
+// result of this code example: https://i.imgur.com/mzIQ86x.png
 ```
 

--- a/HUD/SetMultiplayerBankCash.md
+++ b/HUD/SetMultiplayerBankCash.md
@@ -10,7 +10,7 @@ void SET_MULTIPLAYER_BANK_CASH();
 
 Preview image:
 
-![](https://i.imgur.com/1BTmdyv.png)
+![](https://i.imgur.com/055yfLG.png)
 
 To change the bank balance use [`STAT_SET_INT`](#_0xB3271D7AB655B441) with "BANK_BALANCE" to whatever value you need to.
 

--- a/HUD/SetMultiplayerWalletCash.md
+++ b/HUD/SetMultiplayerWalletCash.md
@@ -11,7 +11,7 @@ void SET_MULTIPLAYER_WALLET_CASH();
 
 Preview image:
 
-![](https://i.imgur.com/1BTmdyv.png)
+![](https://i.imgur.com/055yfLG.png)
 
 To change money value use [`STAT_SET_INT`](#_0xB3271D7AB655B441) with "MP0_WALLET_BALANCE" to whatever value you need to.
 

--- a/HUD/SetWarningMessage.md
+++ b/HUD/SetWarningMessage.md
@@ -74,7 +74,7 @@ enum INSTRUCTIONAL_BUTTON_TYPES
 Note: this list is definitely NOT complete, but these are the ones I've been able to find before giving up because it's such a boring thing to look for 'good' combinations.
 
 **Result of the example code:**
-[https://i.imgur.com/imwoimm.png](https://i.imgur.com/imwoimm.png)
+[https://i.imgur.com/cNm7zZe.png](https://i.imgur.com/cNm7zZe.png)
 
 
 ## Parameters

--- a/HUD/SetWarningMessageWithAlert.md
+++ b/HUD/SetWarningMessageWithAlert.md
@@ -55,7 +55,7 @@ Alt = {
 }
 ```
 
-**Result of the example code:** [https://i.imgur.com/TvmNF4k.png](https://i.imgur.com/TvmNF4k.png)
+**Result of the example code:** [https://i.imgur.com/rZ54JGW.png](https://i.imgur.com/rZ54JGW.png)
 
 ## Parameters
 * **labelTitle**: Label of the alert's title. 

--- a/HUD/ShowCrewIndicatorOnBlip.md
+++ b/HUD/ShowCrewIndicatorOnBlip.md
@@ -9,7 +9,7 @@ aliases: ["0xDCFB5D4DB8BF367E", "SET_BLIP_CREW"]
 void SHOW_CREW_INDICATOR_ON_BLIP(Blip blip, BOOL toggle);
 ```
 
-Enables or disables the blue half circle ![](https://i.imgur.com/iZes9Ec.png) around the specified blip on the left side of the blip. This is used to indicate that the player is in your crew in GTA:O. Color is changeable by using [`SET_BLIP_SECONDARY_COLOUR`](#_0x14892474891E09EB).
+Enables or disables the blue half circle ![](https://i.imgur.com/fbmrbaT.png) around the specified blip on the left side of the blip. This is used to indicate that the player is in your crew in GTA:O. Color is changeable by using [`SET_BLIP_SECONDARY_COLOUR`](#_0x14892474891E09EB).
 
 To toggle the right side of the circle use: [`SHOW_FRIEND_INDICATOR_ON_BLIP`](#_0x23C3EB807312F01A).
 

--- a/HUD/ShowFriendIndicatorOnBlip.md
+++ b/HUD/ShowFriendIndicatorOnBlip.md
@@ -9,7 +9,7 @@ aliases: ["0x23C3EB807312F01A", "SET_BLIP_FRIEND"]
 void SHOW_FRIEND_INDICATOR_ON_BLIP(Blip blip, BOOL toggle);
 ```
 
-Highlights a blip by a half cyan circle on the right side of the blip. ![](https://i.imgur.com/FrV9M4e.png) Indicating that that player is a friend (in GTA:O). This color can not be changed.
+Highlights a blip by a half cyan circle on the right side of the blip. ![](https://i.imgur.com/a51Y36V.png) Indicating that that player is a friend (in GTA:O). This color can not be changed.
 
 To toggle the left side (crew member indicator) of the half circle around the blip, use: [`SHOW_CREW_INDICATOR_ON_BLIP`](#_0xDCFB5D4DB8BF367E).
 

--- a/HUD/StartGpsCustomRoute.md
+++ b/HUD/StartGpsCustomRoute.md
@@ -15,7 +15,7 @@ The GPS custom route works like the GPS multi route, except it does not follow r
 
 **Example result:**
 
-![](https://i.imgur.com/BDm5pzt.png)
+![](https://i.imgur.com/q5wPQyw.png)
 
 ## Parameters
 * **hudColor**: The HUD color of the GPS path.

--- a/HUD/StartGpsMultiRoute.md
+++ b/HUD/StartGpsMultiRoute.md
@@ -17,7 +17,7 @@ Works independently from the player-placed waypoint and blip routes.
 
 **Example result:**
 
-![](https://i.imgur.com/ZZHQatX.png)
+![](https://i.imgur.com/E5CzggL.png)
 
 ## Parameters
 * **hudColor**: The HUD color of the GPS path.

--- a/OBJECT/IsPointInAngledArea.md
+++ b/OBJECT/IsPointInAngledArea.md
@@ -14,8 +14,8 @@ An **angled area** is an X-Z oriented rectangle with three parameters:
 3. **width**: the length of the base edge; (named derived from logging strings ``CNetworkRoadNodeWorldStateData``).
 
 The oriented rectangle can then be derived from the direction of the two points (``norm(origin - extent)``), its orthonormal, and the width, e.g:
-1. [golf_mp](https://i.imgur.com/JhsQAK9.png)
-2. [am_taxi](https://i.imgur.com/TJWCZaT.jpg)
+1. [golf_mp](https://i.imgur.com/p14LFfr.png)
+2. [am_taxi](https://i.imgur.com/sABN3jj.png)
 
 ## Parameters
 * **xPos**: The x coordinate.

--- a/PATHFIND/SetGpsDisabledZoneAtIndex.md
+++ b/PATHFIND/SetGpsDisabledZoneAtIndex.md
@@ -15,9 +15,9 @@ You can clear the disabled zone with CLEAR_GPS_DISABLED_ZONE_AT_INDEX.
 
 **Setting a waypoint at the same coordinate:**
 
-Disabled Zone: [https://i.imgur.com/P9VUuxM.png](https://i.imgur.com/P9VUuxM.png)
+Disabled Zone: [https://i.imgur.com/Tpi3wkl.png](https://i.imgur.com/Tpi3wkl.png)
 
-Enabled Zone (normal): [https://i.imgur.com/BPi24aw.png](https://i.imgur.com/BPi24aw.png)
+Enabled Zone (normal): [https://i.imgur.com/6fHmOOA.png](https://i.imgur.com/6fHmOOA.png)
 
 
 ## Parameters

--- a/PED/RegisterPedheadshotTransparent.md
+++ b/PED/RegisterPedheadshotTransparent.md
@@ -12,7 +12,7 @@ int REGISTER_PEDHEADSHOT_TRANSPARENT(Ped ped);
 Similar to REGISTER_PEDHEADSHOT but creates a transparent background instead of black.
 
 **Result of the example code:**
-[https://i.imgur.com/iHz8ztn.png](https://i.imgur.com/iHz8ztn.png)
+[https://i.imgur.com/vMj15QZ.png](https://i.imgur.com/vMj15QZ.png)
 
 ## Parameters
 * **ped**: A ped handle.

--- a/VEHICLE/SetVehicleEnveffScale.md
+++ b/VEHICLE/SetVehicleEnveffScale.md
@@ -11,9 +11,9 @@ void SET_VEHICLE_ENVEFF_SCALE(Vehicle vehicle, float fade);
 
 Examples with a besra:
 
-- [fade value `0.0`](https://i.imgur.com/DXNk63e.jpg)
-- [fade value `0.5`](https://i.imgur.com/2Vb35fq.jpg)
-- [fade value `1.0`](https://i.imgur.com/aa8cxaD.jpg)
+- [fade value `0.0`](https://i.imgur.com/CiGTTOw.png)
+- [fade value `0.5`](https://i.imgur.com/omJKyzR.png)
+- [fade value `1.0`](https://i.imgur.com/fqAq73t.png)
 
 The parameter fade is a value from 0-1, where 0 is fresh paint.
 

--- a/VEHICLE/SetVehicleXenonLightsColor.md
+++ b/VEHICLE/SetVehicleXenonLightsColor.md
@@ -18,7 +18,7 @@ You can find the list of colors and ids here: [_GET_VEHICLE_HEADLIGHTS_COLOUR](#
 * **color**: The paint index.
 
 **Result**:
-> ![](https://i.imgur.com/yV3cpG9.png)
+> ![](https://i.imgur.com/21tdrg0.png)
 
 ## Examples
 


### PR DESCRIPTION
Many Imgur images were deleted at some point within the last year, this PR restores a fair few of them. Please let me know if I'm missing any not listed below.

Note this PR does NOT restore any dead links found in "unmodern" docs.

 The following links I could not find anything for:
- https://i.imgur.com/qLbXWcQ.png in AddBlipForArea.md
- https://i.imgur.com/0j7O7Rh.png in AddBlipForArea.md
- https://i.imgur.com/hS6ki7p.png in SetRadiusBlipEdge.md