### PR TITLE
feat(vehicle/SetVehicleDoorsLocked): update c# example

### DIFF
--- a/VEHICLE/SetVehicleDoorsLocked.md
+++ b/VEHICLE/SetVehicleDoorsLocked.md
@@ -73,21 +73,25 @@ RegisterCommand("unlockcar", () => {
 ```
 
 ```csharp
-using static CitizenFX.Core.Native.API;
+using CitizenFX.Core;
 
 // Command to lock the car of the player for everyone.
 RegisterCommand("lockcar", () => {
-    Ped playerPed = PlayerPedId(); // Get the player ped
-    Vehicle vehicle = GetVehiclePedIsIn(playerPed, false); // Get the vehicle the player is in
-    if (vehicle == 0) return; // If the player is not in a vehicle, return
-    SetVehicleDoorsLocked(vehicle, 2); // Lock the doors of the vehicle
+    Vehicle vehicle = Game.PlayerPed.CurrentVehicle; // Get the vehicle the player is in (with the C# wrapper)
+    if (vehicle == null)
+    {
+        return; // If the player is not in a vehicle, return
+    }
+    vehicle.LockStatus = VehicleLockStatus.Locked; // Lock the vehicle
 }, false);
 
 // Command to unlock the car of the player for everyone.
 RegisterCommand("unlockcar", () => {
-    Ped playerPed = PlayerPedId(); // Get the player ped
-    Vehicle vehicle = GetVehiclePedIsIn(playerPed, false); // Get the vehicle the player is in
-    if (vehicle == 0) return; // If the player is not in a vehicle, return
-    SetVehicleDoorsLocked(vehicle, 1); // Unlock the doors of the vehicle
+    Vehicle vehicle = Game.PlayerPed.CurrentVehicle; // Get the vehicle the player is in (with the C# wrapper)
+    if (vehicle == null)
+    {
+        return; // If the player is not in a vehicle, return
+    }
+    vehicle.LockStatus = VehicleLockStatus.Unlocked; // Unlock the doors of the vehicle
 }, false);
 ```


### PR DESCRIPTION
Update SET_VEHICLE_DOORS_LOCKED examples on the C# version to use the c# wrapper, thanks to Quadruplex & VIRUXE for explaining me how is it working

Someone should update the enum in the [c# wrapper](https://github.com/citizenfx/fivem/blob/8b93ef263f644196fd83621df65c3c0b687da124/code/client/clrcore/External/Vehicle.cs#L307) btw 