### PR TITLE
fix(doc/blip): correct link and param

### DIFF
--- a/HUD/RemoveBlip.md
+++ b/HUD/RemoveBlip.md
@@ -5,7 +5,7 @@ ns: HUD
 
 ```c
 // 0x86A652570E5F25DD 0xD8C3C1CD
-void REMOVE_BLIP(int* blip);
+void REMOVE_BLIP(int blip);
 ```
 
 Removes the blip from your map.

--- a/HUD/RemoveBlip.md
+++ b/HUD/RemoveBlip.md
@@ -10,8 +10,6 @@ void REMOVE_BLIP(Blip* blip);
 
 Removes the blip from your map.
 
-**Note:** This function only works on the script that created the blip, if you wish to remove blips created by other scripts, see [`SET_THIS_SCRIPT_CAN_REMOVE_BLIPS_CREATED_BY_ANY_SCRIPT`](#_0x86A652570E5F25DD).
-
 ## Parameters
 * **blip**: Blip handle to remove.
 

--- a/HUD/RemoveBlip.md
+++ b/HUD/RemoveBlip.md
@@ -5,7 +5,7 @@ ns: HUD
 
 ```c
 // 0x86A652570E5F25DD 0xD8C3C1CD
-void REMOVE_BLIP(char* blip);
+void REMOVE_BLIP(int* blip);
 ```
 
 Removes the blip from your map.

--- a/HUD/RemoveBlip.md
+++ b/HUD/RemoveBlip.md
@@ -5,7 +5,7 @@ ns: HUD
 
 ```c
 // 0x86A652570E5F25DD 0xD8C3C1CD
-void REMOVE_BLIP(Blip* blip);
+void REMOVE_BLIP(char* blip);
 ```
 
 Removes the blip from your map.

--- a/HUD/RemoveBlip.md
+++ b/HUD/RemoveBlip.md
@@ -10,6 +10,8 @@ void REMOVE_BLIP(Blip* blip);
 
 Removes the blip from your map.
 
+**Note:** This native only works on the script that created the blip, if you wish to remove blips created by other scripts, see [`SET_THIS_SCRIPT_CAN_REMOVE_BLIPS_CREATED_BY_ANY_SCRIPT`](#_0xB98236CAAECEF897).
+
 ## Parameters
 * **blip**: Blip handle to remove.
 


### PR DESCRIPTION
Reference for the link should be [this](https://docs.fivem.net/natives/?_0xB98236CAAECEF897) instead of the current link commit.

This reverts citizenfx/natives#1060 commit