### PR TITLE
fix(audio): fix enum not having a closing tag.

### DIFF
--- a/AUDIO/SetAnimalMood.md
+++ b/AUDIO/SetAnimalMood.md
@@ -15,6 +15,7 @@ enum eAudAnimalMood {
 
 	AUD_ANIMAL_MOOD_NUM_MOODS
 }
+```
 
 
 ## Parameters


### PR DESCRIPTION
Noticed this when scrolling through natives, fixes my oversight in one of the audio batch updates