### PR TITLE
tweak(docs/native): Update Task Native Enums & Params

### DIFF
--- a/TASK/SetDriveTaskDrivingStyle.md
+++ b/TASK/SetDriveTaskDrivingStyle.md
@@ -10,14 +10,7 @@ void SET_DRIVE_TASK_DRIVING_STYLE(Ped ped, int drivingStyle);
 
 Sets the driving style for a ped currently performing a driving task.
 
-```
-This native is used to set the driving style for specific ped.  
-Driving styles id seems to be:  
-786468  
-262144  
-786469  
-http://gtaforums.com/topic/822314-guide-driving-styles/  
-```
+Each flag in the `VehicleDrivingFlags` enum can be combined to create a driving style, with each enabling or disabling a specific driving behavior. The driving style can be set to one of the predefined driving styles, or a custom driving style can be created by combining the flags. This can be done by using the bitwise OR operator (`|`) to combine the flags or by adding the decimal values of the flags together.
 
 ```c
 enum VehicleDrivingFlags
@@ -66,5 +59,23 @@ enum VehicleDrivingFlags
 ```
 
 ## Parameters
-* **ped**: The ped have their driving style set.
-* **drivingStyle**: The driving style to set (see `VehicleDrivingFlags`).
+* **ped**: The ped to have their driving style set.
+* **drivingStyle**: The driving style (see `VehicleDrivingFlags`).
+
+## Examples
+
+```lua
+local model = `adder`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId() -- Player needs to be in a vehicle for this to work
+local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
+local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskVehicleChase(driver, ped)
+SetDriveTaskDrivingStyle(driver, 786468) -- DrivingModeAvoidVehiclesReckless
+SetPedKeepTask(driver, true)
+```

--- a/TASK/SetDriveTaskDrivingStyle.md
+++ b/TASK/SetDriveTaskDrivingStyle.md
@@ -10,10 +10,10 @@ void SET_DRIVE_TASK_DRIVING_STYLE(Ped ped, int drivingStyle);
 
 Sets the driving style for a ped currently performing a driving task.
 
-Each flag in the `VehicleDrivingFlags` enum can be combined to create a driving style, with each enabling or disabling a specific driving behavior. The driving style can be set to one of the predefined driving styles, or a custom driving style can be created by combining the flags. This can be done by using the bitwise OR operator (`|`) to combine the flags or by adding the decimal values of the flags together.
+Each flag in the `eVehicleDrivingFlags` enum can be combined to create a driving style, with each enabling or disabling a specific driving behavior. The driving style can be set to one of the predefined driving styles, or a custom driving style can be created by combining the flags. This can be done by using the bitwise OR operator (`|`) to combine the flags or by adding the decimal values of the flags together.
 
 ```c
-enum VehicleDrivingFlags
+enum eVehicleDrivingFlags
 {
   None = 0,
   StopForVehicles = 1,
@@ -60,7 +60,7 @@ enum VehicleDrivingFlags
 
 ## Parameters
 * **ped**: The ped to have their driving style set.
-* **drivingStyle**: The driving style (see `VehicleDrivingFlags`).
+* **drivingStyle**: The driving style (see `eVehicleDrivingFlags`).
 
 ## Examples
 

--- a/TASK/SetDriveTaskDrivingStyle.md
+++ b/TASK/SetDriveTaskDrivingStyle.md
@@ -76,6 +76,7 @@ RequestModel(model)
 repeat Wait(0) until HasModelLoaded(model)
 local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
 TaskVehicleChase(driver, ped)
-SetDriveTaskDrivingStyle(driver, 786468) -- DrivingModeAvoidVehiclesReckless
+SetDriveTaskDrivingStyle(driver, 786468)
+-- Driving Style: DrivingModeAvoidVehiclesReckless
 SetPedKeepTask(driver, true)
 ```

--- a/TASK/SetDriveTaskDrivingStyle.md
+++ b/TASK/SetDriveTaskDrivingStyle.md
@@ -65,16 +65,22 @@ enum VehicleDrivingFlags
 ## Examples
 
 ```lua
-local model = `adder`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local vehicle_model = `adder`
+RequestModel(vehicle_model)
+repeat Wait(0) until HasModelLoaded(vehicle_model)
+
 local ped = PlayerPedId() -- Player needs to be in a vehicle for this to work
 local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
-local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+local vehicle = CreateVehicle(vehicle_model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+SetModelAsNoLongerNeeded(vehicle_model) -- Allow the game engine to clear the model from memory
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local driver = CreatePedInsideVehicle(vehicle, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskVehicleChase(driver, ped)
 SetDriveTaskDrivingStyle(driver, 786468)
 -- Driving Style: DrivingModeAvoidVehiclesReckless

--- a/TASK/SetDriveTaskDrivingStyle.md
+++ b/TASK/SetDriveTaskDrivingStyle.md
@@ -8,6 +8,8 @@ ns: TASK
 void SET_DRIVE_TASK_DRIVING_STYLE(Ped ped, int drivingStyle);
 ```
 
+Sets the driving style for a ped currently performing a driving task.
+
 ```
 This native is used to set the driving style for specific ped.  
 Driving styles id seems to be:  
@@ -17,7 +19,52 @@ Driving styles id seems to be:
 http://gtaforums.com/topic/822314-guide-driving-styles/  
 ```
 
-## Parameters
-* **ped**: 
-* **drivingStyle**: 
+```c
+enum VehicleDrivingFlags
+{
+  None = 0,
+  StopForVehicles = 1,
+  StopForPeds = 2,
+  SwerveAroundAllVehicles = 4,
+  SteerAroundStationaryVehicles = 8,
+  SteerAroundPeds = 16,
+  SteerAroundObjects = 32,
+  DontSteerAroundPlayerPed = 64,
+  StopAtTrafficLights = 128,
+  GoOffRoadWhenAvoiding = 256,
+  AllowGoingWrongWay = 512,
+  Reverse = 1024,
+  UseWanderFallbackInsteadOfStraightLine = 2048,
+  AvoidRestrictedAreas = 4096,
+  PreventBackgroundPathfinding = 8192,
+  AdjustCruiseSpeedBasedOnRoadSpeed = 16384,
+  UseShortCutLinks = 262144,
+  ChangeLanesAroundObstructions = 524288,
+  UseSwitchedOffNodes = 2097152,
+  PreferNavmeshRoute = 4194304,
+  PlaneTaxiMode = 8388608,
+  ForceStraightLine = 16777216,
+  UseStringPullingAtJunctions = 33554432,
+  TryToAvoidHighways = 536870912,
+  ForceJoinInRoadDirection = 1073741824,
+  StopAtDestination = 2147483648,
+  // StopForVehicles | StopForPeds | SteerAroundObjects | SteerAroundStationaryVehicles | StopAtTrafficLights | UseShortCutLinks | ChangeLanesAroundObstructions
+  DrivingModeStopForVehicles = 786603,
+  // StopForVehicles | StopForPeds | StopAtTrafficLights | UseShortCutLinks
+  DrivingModeStopForVehiclesStrict = 262275,
+  // SwerveAroundAllVehicles | SteerAroundObjects | UseShortCutLinks | ChangeLanesAroundObstructions | StopForVehicles
+  DrivingModeAvoidVehicles = 786469,
+  // SwerveAroundAllVehicles | SteerAroundObjects | UseShortCutLinks | ChangeLanesAroundObstructions
+  DrivingModeAvoidVehiclesReckless = 786468,
+  // StopForVehicles | SteerAroundStationaryVehicles | StopForPeds | SteerAroundObjects | UseShortCutLinks | ChangeLanesAroundObstructions
+  DrivingModeStopForVehiclesIgnoreLights = 786475,
+  // SwerveAroundAllVehicles | StopAtTrafficLights | SteerAroundObjects | UseShortCutLinks | ChangeLanesAroundObstructions | StopForVehicles
+  DrivingModeAvoidVehiclesObeyLights = 786597,
+  // SwerveAroundAllVehicles | StopAtTrafficLights | StopForPeds | SteerAroundObjects | UseShortCutLinks | ChangeLanesAroundObstructions | StopForVehicles
+  DrivingModeAvoidVehiclesStopForPedsObeyLights = 786599,
+}
+```
 
+## Parameters
+* **ped**: The ped have their driving style set.
+* **drivingStyle**: The driving style to set (see `VehicleDrivingFlags`).

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -64,5 +64,6 @@ RequestModel(model)
 repeat Wait(0) until HasModelLoaded(model)
 local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
 TaskBoatMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 0, 0.0, 0.0, 0.0, 7, -1.0, 786468, -1.0, 1044)
+-- Drive Style: DrivingModeAvoidVehiclesReckless | Mission Flags: AvoidShore | NeverStop | NeverPause
 SetPedKeepTask(driver, true)
 ```

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -8,7 +8,7 @@ ns: TASK
 void TASK_BOAT_MISSION(Ped ped, Vehicle boat, Vehicle vehicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, int drivingStyle, float radius, int missionFlags);
 ```
 
-All parameters except driver and boat are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle). 
+All parameters except ped and boat are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).
 
 If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
 
@@ -24,6 +24,7 @@ P8 appears to be driving style flag - see gtaforums.com/topic/822314-guide-drivi
 ```c
 enum BoatMissionFlags
 {
+  None = 0,
   StopAtEnd = 1,
   StopAtShore = 2,
   AvoidShore = 4,
@@ -47,13 +48,13 @@ enum BoatMissionFlags
 ## Parameters
 * **ped**: The ped to be tasked.
 * **boat**: The boats' entity handle.
-* **vehicleTarget**: The target vehicle (default is 0)
-* **pedTarget**: The target ped (default is 0)
-* **x**: The x coordinate of the target (default is 0.0f)
-* **y**: The y coordinate of the target (default is 0.0f)
-* **z**: The z coordinate of the target (default is 0.0f)
-* **missionType**: The mission type (default is 0)
-* **speed**: The speed in m/s (default is -1.0f)
-* **drivingStyle**: The driving style (default is 0)
-* **radius**: The radius of when the task will be completed (default is -1.0f)
-* **missionFlags**: The mission flags (default is 0) (see `BoatMissionFlags`)
+* **vehicleTarget**: The target vehicle (default is 0).
+* **pedTarget**: The target ped (default is 0).
+* **x**: The x coordinate of the target (default is 0.0f).
+* **y**: The y coordinate of the target (default is 0.0f).
+* **z**: The z coordinate of the target (default is 0.0f).
+* **missionType**: The mission type (default is 0).
+* **speed**: The speed in m/s (default is -1.0f).
+* **drivingStyle**: The driving style (default is 0).
+* **radius**: The radius of when the task will be completed (default is -1.0f).
+* **missionFlags**: The mission flags (default is 0) (see `BoatMissionFlags`).

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -64,6 +64,6 @@ RequestModel(model)
 repeat Wait(0) until HasModelLoaded(model)
 local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
 TaskBoatMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 0, 0.0, 0.0, 0.0, 7, -1.0, 786468, -1.0, 1044)
--- Drive Style: DrivingModeAvoidVehiclesReckless | Mission Flags: AvoidShore | NeverStop | NeverPause
+-- Mission Type: Follow | Drive Style: DrivingModeAvoidVehiclesReckless | Mission Flags: AvoidShore | NeverStop | NeverPause
 SetPedKeepTask(driver, true)
 ```

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -53,16 +53,22 @@ enum BoatMissionFlags
 ## Examples
 
 ```lua
-local model = `tropic`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local boat_model = `tropic`
+RequestModel(boat_model)
+repeat Wait(0) until HasModelLoaded(boat_model)
+
 local ped = PlayerPedId() -- Player needs to be in open water & in a boat for this to work
 local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
-local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+local vehicle = CreateVehicle(boat_model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+SetModelAsNoLongerNeeded(boat_model) -- Allow the game engine to clear the model from memory
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local driver = CreatePedInsideVehicle(vehicle, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskBoatMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 0, 0.0, 0.0, 0.0, 7, -1.0, 786468, -1.0, 1044)
 -- Mission Type: Follow | Drive Style: DrivingModeAvoidVehiclesReckless | Mission Flags: AvoidShore | NeverStop | NeverPause
 SetPedKeepTask(driver, true)

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -44,9 +44,9 @@ enum BoatMissionFlags
 * **x**: The x coordinate of the target (default is 0.0f).
 * **y**: The y coordinate of the target (default is 0.0f).
 * **z**: The z coordinate of the target (default is 0.0f).
-* **missionType**: The mission type (default is 0) (see ![TaskVehicleMission](#_0x659427E0EF36BCDE)).
+* **missionType**: The mission type (default is 0) (see [TaskVehicleMission](#_0x659427E0EF36BCDE)).
 * **speed**: The speed in m/s (default is -1.0f).
-* **drivingStyle**: The driving style (default is 0) (see ![SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **radius**: The radius of when the task will be completed (default is -1.0f).
 * **missionFlags**: The mission flags (default is 0) (see `BoatMissionFlags`).
 

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -12,15 +12,6 @@ All parameters except ped and boat are optional, with `pedTarget`, `vehicleTarge
 
 If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
 
-```
-You need to call PED::SET_BLOCKING_OF_NON_TEMPORARY_EVENTS after TASK_BOAT_MISSION in order for the task to execute.
-Working example
-float vehicleMaxSpeed = VEHICLE::_GET_VEHICLE_MAX_SPEED(ENTITY::GET_ENTITY_MODEL(pedVehicle));
-TASK::TASK_BOAT_MISSION(pedDriver, pedVehicle, 0, 0, waypointCoord.x, waypointCoord.y, waypointCoord.z, 4, vehicleMaxSpeed, 786469, -1.0, 7);
-PED::SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(pedDriver, 1);
-P8 appears to be driving style flag - see gtaforums.com/topic/822314-guide-driving-styles/ for documentation
-```
-
 ```c
 enum BoatMissionFlags
 {
@@ -53,8 +44,25 @@ enum BoatMissionFlags
 * **x**: The x coordinate of the target (default is 0.0f).
 * **y**: The y coordinate of the target (default is 0.0f).
 * **z**: The z coordinate of the target (default is 0.0f).
-* **missionType**: The mission type (default is 0).
+* **missionType**: The mission type (default is 0) (see ![TaskVehicleMission](#_0x659427E0EF36BCDE)).
 * **speed**: The speed in m/s (default is -1.0f).
-* **drivingStyle**: The driving style (default is 0).
+* **drivingStyle**: The driving style (default is 0) (see ![SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **radius**: The radius of when the task will be completed (default is -1.0f).
 * **missionFlags**: The mission flags (default is 0) (see `BoatMissionFlags`).
+
+## Examples
+
+```lua
+local model = `tropic`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId() -- Player needs to be in open water & in a boat for this to work
+local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
+local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskBoatMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 0, 0.0, 0.0, 0.0, 7, -1.0, 786468, -1.0, 1044)
+SetPedKeepTask(driver, true)
+```

--- a/TASK/TaskBoatMission.md
+++ b/TASK/TaskBoatMission.md
@@ -13,7 +13,7 @@ All parameters except ped and boat are optional, with `pedTarget`, `vehicleTarge
 If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
-enum BoatMissionFlags
+enum eBoatMissionFlags
 {
   None = 0,
   StopAtEnd = 1,
@@ -48,7 +48,7 @@ enum BoatMissionFlags
 * **speed**: The speed in m/s (default is -1.0f).
 * **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **radius**: The radius of when the task will be completed (default is -1.0f).
-* **missionFlags**: The mission flags (default is 0) (see `BoatMissionFlags`).
+* **missionFlags**: The mission flags (default is 0) (see `eBoatMissionFlags`).
 
 ## Examples
 

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -61,13 +61,13 @@ RequestModel(model)
 repeat Wait(0) until HasModelLoaded(model)
 local ped = PlayerPedId() -- Player needs to be outside for this to work
 local coords = GetEntityCoords(ped) + GetEntityForwardVector(ped) * 100.0
-local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z + 50.0, GetEntityHeading(ped) - 180.0, true, false)
-SetHeliBladesFullSpeed(vehicle)
+local heli = CreateVehicle(model, coords.x, coords.y, coords.z + 50.0, GetEntityHeading(ped) - 180.0, true, false)
+SetHeliBladesFullSpeed(heli)
 model = `a_m_m_skater_01`
 RequestModel(model)
 repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
-TaskHeliMission(driver, vehicle, 0, 0, coords.x, coords.y, coords.z, 19, 10.0, -1.0, -1.0, -1.0, -1.0, -1.0, 96)
+local pilot = CreatePedInsideVehicle(heli, 0, model, -1, true, false)
+TaskHeliMission(pilot, heli, 0, 0, coords.x, coords.y, coords.z, 19, 10.0, -1.0, -1.0, -1.0, -1.0, -1.0, 96)
 -- Mission Type: Land | Mission Flags: LandOnArrival | DontDoAvoidance
-SetPedKeepTask(driver, true)
+SetPedKeepTask(pilot, true)
 ```

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -5,8 +5,12 @@ ns: TASK
 
 ```c
 // 0xDAD029E187A2BEB4 0x0C143E97
-void TASK_HELI_MISSION(Ped pilot, Vehicle aircraft, Vehicle targetVehicle, Ped targetPed, float destinationX, float destinationY, float destinationZ, int missionFlag, float maxSpeed, float landingRadius, float targetHeading, int unk1, int unk2, cs_type(Hash) float unk3, int landingFlags);
+void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vahicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(Int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
 ```
+
+All parameters except ped and heli are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).
+
+If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
 
 ```
 Needs more research.
@@ -28,20 +32,43 @@ mode 4 or 7 forces heli to snap to the heading set
 I change p2 to 'vehicleToFollow' as it seems to work like the task natives to set targets. In the heli_taxi script where as the merryweather heli takes you to your waypoint it has no need to follow a vehicle or a ped, so of course both have 0 set.
 ```
 
-## Parameters
-* **pilot**: 
-* **aircraft**: 
-* **targetVehicle**: 
-* **targetPed**: 
-* **destinationX**: 
-* **destinationY**: 
-* **destinationZ**: 
-* **missionFlag**: 
-* **maxSpeed**: 
-* **landingRadius**: 
-* **targetHeading**: 
-* **unk1**: 
-* **unk2**: 
-* **unk3**: 
-* **landingFlags**: 
+```c
+enum HeliMissionFlags
+{
+  None = 0,
+  AttainRequestedOrientation = 1,
+  DontModifyOrientation = 2,
+  DontModifyPitch = 4,
+  DontModifyThrottle = 8,
+  DontModifyRoll = 16,
+  LandOnArrival = 32,
+  DontDoAvoidance = 64,
+  StartEngineImmediately = 128,
+  ForceHeightMapAvoidance = 256,
+  DontClampProbesToDestination = 512,
+  EnableTimeslicingWhenPossible = 1024,
+  CircleOppositeDirection = 2048,
+  MaintainHeightAboveTerrain = 4096,
+  IgnoreHiddenEntitiesDuringLand = 8192,
+  DisableAllHeightMapAvoidance = 16384,
+  // ForceHeightMapAvoidance | DontDoAvoidance
+  HeightMapOnlyAvoidance = 320,
+}
+```
 
+## Parameters
+* **ped**: The ped to be tasked.
+* **heli**: The helicopters' entity handle.
+* **vehicleTarget**: The target vehicle (default is 0).
+* **pedTarget**: The target ped (default is 0).
+* **x**: The x coordinate of the target (default is 0.0f).
+* **y**: The y coordinate of the target (default is 0.0f).
+* **z**: The z coordinate of the target (default is 0.0f).
+* **missionType**: The mission type (default is 0).
+* **speed**: The speed in m/s (default is -1.0f).
+* **radius**: The radius of when the task will be completed (default is -1.0f).
+* **heading**:  The heading the helicopter will face at task completion (default is -1.0f).
+* **height**: The height the helicopter will fly at (default is -1.0f).
+* **minHeight**: The height the helicopter will not fly below (default is -1.0f).
+* **slowDist**: The distance to the target at which the helicopter will slow down (default is -1.0f).
+* **missionFlags**: The mission flags (default is 0) (see `HeliMissionFlags`).

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -13,7 +13,7 @@ All parameters except ped, heli and speed are optional, with `pedTarget`, `vehic
 If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget`, `0` for other int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
-enum HeliMissionFlags
+enum eHeliMissionFlags
 {
   None = 0,
   AttainRequestedOrientation = 1,
@@ -51,7 +51,7 @@ enum HeliMissionFlags
 * **height**: The height the helicopter will fly at (default is -1.0f).
 * **minHeight**: The height the helicopter will not fly below (default is -1.0f).
 * **slowDist**: The distance to the target at which the helicopter will slow down (default is -1.0f).
-* **missionFlags**: The mission flags (default is 0) (see `HeliMissionFlags`).
+* **missionFlags**: The mission flags (default is 0) (see `eHeliMissionFlags`).
 
 ## Examples
 

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -56,17 +56,23 @@ enum HeliMissionFlags
 ## Examples
 
 ```lua
-local model = `akula`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local heli_model = `akula`
+RequestModel(heli_model)
+repeat Wait(0) until HasModelLoaded(heli_model)
+
 local ped = PlayerPedId() -- Player needs to be outside for this to work
 local coords = GetEntityCoords(ped) + GetEntityForwardVector(ped) * 100.0
-local heli = CreateVehicle(model, coords.x, coords.y, coords.z + 50.0, GetEntityHeading(ped) - 180.0, true, false)
+local heli = CreateVehicle(heli_model, coords.x, coords.y, coords.z + 50.0, GetEntityHeading(ped) - 180.0, true, false)
+SetModelAsNoLongerNeeded(heli_model) -- Allow the game engine to clear the model from memory
 SetHeliBladesFullSpeed(heli)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local pilot = CreatePedInsideVehicle(heli, 0, model, -1, true, false)
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local pilot = CreatePedInsideVehicle(heli, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskHeliMission(pilot, heli, 0, 0, coords.x, coords.y, coords.z, 19, 10.0, -1.0, -1.0, -1.0, -1.0, -1.0, 96)
 -- Mission Type: Land | Mission Flags: LandOnArrival | DontDoAvoidance
 SetPedKeepTask(pilot, true)

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -44,7 +44,7 @@ enum HeliMissionFlags
 * **x**: The x coordinate of the target (default is 0.0f).
 * **y**: The y coordinate of the target (default is 0.0f).
 * **z**: The z coordinate of the target (default is 0.0f).
-* **missionType**: The mission type (default is 0) (see ![TaskVehicleMission](#_0x659427E0EF36BCDE)).
+* **missionType**: The mission type (default is 0) (see [TaskVehicleMission](#_0x659427E0EF36BCDE)).
 * **speed**: The speed in m/s.
 * **radius**: The radius of when the task will be completed (default is -1.0f).
 * **heading**:  The heading the helicopter will face at task completion (default is -1.0f).

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -8,29 +8,9 @@ ns: TASK
 void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vehicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
 ```
 
-All parameters except ped and heli are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).
+All parameters except ped, heli and speed are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).
 
-If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
-
-```
-Needs more research.
-Default value of p13 is -1.0 or 0xBF800000.
-Default value of p14 is 0.
-Modified examples from "fm_mission_controller.ysc", line ~203551:
-TASK::TASK_HELI_MISSION(ped, vehicle, 0, 0, posX, posY, posZ, 4, 1.0, -1.0, -1.0, 10, 10, 5.0, 0);
-TASK::TASK_HELI_MISSION(ped, vehicle, 0, 0, posX, posY, posZ, 4, 1.0, -1.0, -1.0, 0, ?, 5.0, 4096);
-int mode seams to set mission type 4 = coords target, 23 = ped target.
-int 14 set to 32 = ped will land at destination.
-My findings:
-mode 4 or 7 forces heli to snap to the heading set
-8 makes the heli flee from the ped.
-9 circles around ped with angle set
-10, 11 normal + imitate ped heading
-20 makes the heli land when he's near the ped. It won't resume chasing.
-21 emulates an helicopter crash
-23 makes the heli circle erratically around ped
-I change p2 to 'vehicleToFollow' as it seems to work like the task natives to set targets. In the heli_taxi script where as the merryweather heli takes you to your waypoint it has no need to follow a vehicle or a ped, so of course both have 0 set.
-```
+If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget`, `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
 enum HeliMissionFlags
@@ -64,11 +44,30 @@ enum HeliMissionFlags
 * **x**: The x coordinate of the target (default is 0.0f).
 * **y**: The y coordinate of the target (default is 0.0f).
 * **z**: The z coordinate of the target (default is 0.0f).
-* **missionType**: The mission type (default is 0).
-* **speed**: The speed in m/s (default is -1.0f).
+* **missionType**: The mission type (default is 0) (see ![TaskVehicleMission](#_0x659427E0EF36BCDE)).
+* **speed**: The speed in m/s.
 * **radius**: The radius of when the task will be completed (default is -1.0f).
 * **heading**:  The heading the helicopter will face at task completion (default is -1.0f).
 * **height**: The height the helicopter will fly at (default is -1.0f).
 * **minHeight**: The height the helicopter will not fly below (default is -1.0f).
 * **slowDist**: The distance to the target at which the helicopter will slow down (default is -1.0f).
 * **missionFlags**: The mission flags (default is 0) (see `HeliMissionFlags`).
+
+## Examples
+
+```lua
+local model = `akula`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId() -- Player needs to be outside for this to work
+local coords = GetEntityCoords(ped) + GetEntityForwardVector(ped) * 100.0
+local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z + 50.0, GetEntityHeading(ped) - 180.0, true, false)
+SetHeliBladesFullSpeed(vehicle)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskHeliMission(driver, vehicle, 0, 0, coords.x, coords.y, coords.z, 19, 10.0, -1.0, -1.0, -1.0, -1.0, -1.0, 96)
+-- Mission Type: Land | Mission Flags: LandOnArrival | DontDoAvoidance
+SetPedKeepTask(driver, true)
+```

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0xDAD029E187A2BEB4 0x0C143E97
-void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vehicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(Int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
+void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vehicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
 ```
 
 All parameters except ped and heli are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0xDAD029E187A2BEB4 0x0C143E97
-void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vahicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(Int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
+void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vehicleTarget, Ped pedTarget, float x, float y, float z, int missionType, float speed, float radius, float heading, cs_type(Int) float height, float minHeight, cs_type(Hash) float slowDist, int missionFlags);
 ```
 
 All parameters except ped and heli are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).

--- a/TASK/TaskHeliMission.md
+++ b/TASK/TaskHeliMission.md
@@ -10,7 +10,7 @@ void TASK_HELI_MISSION(Ped ped, Vehicle heli, Vehicle vehicleTarget, Ped pedTarg
 
 All parameters except ped, heli and speed are optional, with `pedTarget`, `vehicleTarget`, `x`, `y`, `z` being dependent on `missionType` (ie. Attack/Flee mission types require a target ped/vehicle, whereas GoTo mission types require either `x`, `y`, `z` or a target ped/vehicle).
 
-If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget`, `0` for int parameters, and `-1.0f` for the remaining float parameters.
+If you don't want to use a parameter; pass `0.0f` for `x`, `y` and `z`, `0` for `pedTarget`, `vehicleTarget`, `0` for other int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
 enum HeliMissionFlags

--- a/TASK/TaskVehicleDriveToCoordLongrange.md
+++ b/TASK/TaskVehicleDriveToCoordLongrange.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0x158BB33F920D360C 0x1490182A
-void TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE(Ped ped, Vehicle vehicle, float x, float y, float z, float speed, int driveMode, float stopRange);
+void TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE(Ped ped, Vehicle vehicle, float x, float y, float z, float speed, int drivingStyle, float stopRange);
 ```
 
 You can let your character drive to the destination at the speed and driving style you set. You can use map marks to set the destination.
@@ -17,7 +17,7 @@ You can let your character drive to the destination at the speed and driving sty
 * **y**: Destination Y coordinate.
 * **z**: Destination Z coordinate.
 * **speed**: Speed of driving.
-* **driveMode**: More info can be found [here](https://vespura.com/fivem/drivingstyle/)
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **stopRange**: Stops in the specific range near the destination. 20.0 works fine.
 
 ## Examples

--- a/TASK/TaskVehicleDriveWander.md
+++ b/TASK/TaskVehicleDriveWander.md
@@ -14,7 +14,7 @@ Drive randomly with no destination set.
 * **ped**: Ped id for the task.
 * **vehicle**: Vehicle entity id for the task.
 * **speed**: Speed of driving.
-* **drivingStyle**: More info can be found [here](https://vespura.com/fivem/drivingstyle/)
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 
 ## Examples
 ```cs

--- a/TASK/TaskVehicleEscort.md
+++ b/TASK/TaskVehicleEscort.md
@@ -28,7 +28,7 @@ Driving Styles guide: gtaforums.com/topic/822314-guide-driving-styles/
 * **targetVehicle**: 
 * **mode**: 
 * **speed**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **minDistance**: 
 * **p7**: 
 * **noRoadsDistance**: 

--- a/TASK/TaskVehicleFollow.md
+++ b/TASK/TaskVehicleFollow.md
@@ -19,6 +19,6 @@ drivingStyle: http://gtaforums.com/topic/822314-guide-driving-styles/
 * **vehicle**: 
 * **targetEntity**: 
 * **speed**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **minDistance**: 
 

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -5,21 +5,49 @@ ns: TASK
 
 ```c
 // 0x659427E0EF36BCDE 0x20609E56
-void TASK_VEHICLE_MISSION(Ped driver, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float p4, Any p5, float p6, float p7, BOOL DriveAgainstTraffic);
+void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float speed, cs_type(Any) int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
+
+All parameters except ped and vehicle are optional, with `vehicleTarget` being dependent on `missionType` (ie. Attack/Flee mission types require a target vehicle, whereas GoTo mission types require a target vehicle).
+
+If you don't want to use a parameter; pass `0` for `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
 
 ```
 missionType: https://alloc8or.re/gta5/doc/enums/eVehicleMissionType.txt
 ```
 
-## Parameters
-* **driver**: 
-* **vehicle**: 
-* **vehicleTarget**: 
-* **missionType**: 
-* **p4**: 
-* **p5**: 
-* **p6**: 
-* **p7**: 
-* **DriveAgainstTraffic**: 
+```c
+enum VehicleMissionType
+{
+  None = 0,
+  Cruise = 1,
+  Ram = 2,
+  Block = 3,
+  GoTo = 4,
+  Stop = 5,
+  Attack = 6,
+  Follow = 7,
+  Flee = 8,
+  Circle = 9,
+  Escort = 12,
+  GoToRacing = 14,
+  FollowRecording = 15,
+  PoliceBehaviour = 16,
+  Land = 19,
+  LandAndWait = 20,
+  Crash = 21,
+  PullOver = 22,
+  HeliProtect = 23
+}
+```
 
+## Parameters
+* **ped**: The ped to be tasked.
+* **vehicle**: The vehicles' entity handle.
+* **vehicleTarget**: The target vehicle (default is 0).
+* **missionType**: The mission type (default is 0) (see `VehicleMissionType`).
+* **speed**: The speed in m/s (default is -1.0f).
+* **drivingStyle**: The driving style (default is 0).
+* **radius**: The radius of when the task will be completed (default is -1.0f).
+* **straightLineDist**: The distance before the vehicle will drive straight to the target (default is -1.0f).
+* **DriveAgainstTraffic**: Whether the vehicle should drive against traffic (default is false).

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -10,7 +10,7 @@ void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int m
 
 All parameters except ped, vehicle, vehicleTarget and speed are optional; with `missionType` being only those that require a target vehicle.
 
-If you don't want to use a parameter; pass `0` for `vehicleTarget`, `0` for int parameters, and `-1.0f` for the remaining float parameters.
+If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
 enum VehicleMissionType

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -41,7 +41,7 @@ enum eVehicleMissionType
 * **ped**: The ped to be tasked.
 * **vehicle**: The vehicles' entity handle.
 * **vehicleTarget**: The target vehicle.
-* **missionType**: The mission type (default is 0) (see `VehicleMissionType`).
+* **missionType**: The mission type (default is 0) (see `eVehicleMissionType`).
 * **speed**: The speed in m/s.
 * **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **radius**: The radius of when the task will be completed (default is -1.0f).

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -8,13 +8,9 @@ ns: TASK
 void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float speed, int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
 
-All parameters except ped and vehicle are optional, with `vehicleTarget` being dependent on `missionType` (ie. Attack/Flee mission types require a target vehicle, whereas GoTo mission types require a target vehicle).
+All parameters except ped, vehicle, vehicleTarget and speed are optional; with `missionType` being only those that require a target vehicle.
 
-If you don't want to use a parameter; pass `0` for `vehicleTarget` and other int parameters, and `-1.0f` for the remaining float parameters.
-
-```
-missionType: https://alloc8or.re/gta5/doc/enums/eVehicleMissionType.txt
-```
+If you don't want to use a parameter; pass `0` for `vehicleTarget`, `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
 enum VehicleMissionType
@@ -46,8 +42,26 @@ enum VehicleMissionType
 * **vehicle**: The vehicles' entity handle.
 * **vehicleTarget**: The target vehicle (default is 0).
 * **missionType**: The mission type (default is 0) (see `VehicleMissionType`).
-* **speed**: The speed in m/s (default is -1.0f).
-* **drivingStyle**: The driving style (default is 0).
+* **speed**: The speed in m/s.
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **radius**: The radius of when the task will be completed (default is -1.0f).
 * **straightLineDist**: The distance before the vehicle will drive straight to the target (default is -1.0f).
 * **DriveAgainstTraffic**: Whether the vehicle should drive against traffic (default is false).
+
+## Examples
+
+```lua
+local model = `adder`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId() -- Player needs in a vehicle for this to work
+local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
+local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskVehicleMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 8, 35.0, 786468, -1.0, -1.0, true)
+-- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
+SetPedKeepTask(driver, true)
+```

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -51,16 +51,22 @@ enum VehicleMissionType
 ## Examples
 
 ```lua
-local model = `adder`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local vehicle_model = `adder`
+RequestModel(vehicle_model)
+repeat Wait(0) until HasModelLoaded(vehicle_model)
+
 local ped = PlayerPedId() -- Player needs in a vehicle for this to work
 local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
-local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+local vehicle = CreateVehicle(vehicle_model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+SetModelAsNoLongerNeeded(vehicle_model) -- Allow the game engine to clear the model from memory
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local driver = CreatePedInsideVehicle(vehicle, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskVehicleMission(driver, vehicle, GetVehiclePedIsIn(ped, false), 8, 35.0, 786468, -1.0, -1.0, true)
 -- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
 SetPedKeepTask(driver, true)

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -13,7 +13,7 @@ All parameters except ped, vehicle, vehicleTarget and speed are optional; with `
 If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ```c
-enum VehicleMissionType
+enum eVehicleMissionType
 {
   None = 0,
   Cruise = 1,

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0x659427E0EF36BCDE 0x20609E56
-void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float speed, cs_type(Any) int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
+void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float speed, int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
 
 All parameters except ped and vehicle are optional, with `vehicleTarget` being dependent on `missionType` (ie. Attack/Flee mission types require a target vehicle, whereas GoTo mission types require a target vehicle).

--- a/TASK/TaskVehicleMission.md
+++ b/TASK/TaskVehicleMission.md
@@ -8,7 +8,7 @@ ns: TASK
 void TASK_VEHICLE_MISSION(Ped ped, Vehicle vehicle, Vehicle vehicleTarget, int missionType, float speed, int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
 
-All parameters except ped, vehicle, vehicleTarget and speed are optional; with `missionType` being only those that require a target vehicle.
+All parameters except ped, vehicle, vehicleTarget and speed are optional; with `missionType` being only those that require a target entity.
 
 If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
@@ -40,7 +40,7 @@ enum VehicleMissionType
 ## Parameters
 * **ped**: The ped to be tasked.
 * **vehicle**: The vehicles' entity handle.
-* **vehicleTarget**: The target vehicle (default is 0).
+* **vehicleTarget**: The target vehicle.
 * **missionType**: The mission type (default is 0) (see `VehicleMissionType`).
 * **speed**: The speed in m/s.
 * **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).

--- a/TASK/TaskVehicleMissionCoorsTarget.md
+++ b/TASK/TaskVehicleMissionCoorsTarget.md
@@ -5,21 +5,41 @@ ns: TASK
 
 ```c
 // 0xF0AF20AA7731F8C3 0x6719C109
-void TASK_VEHICLE_MISSION_COORS_TARGET(Ped ped, Vehicle vehicle, float x, float y, float z, int p5, int p6, int p7, float p8, float p9, BOOL DriveAgainstTraffic);
+void TASK_VEHICLE_MISSION_COORS_TARGET(Ped ped, Vehicle vehicle, float x, float y, float z, int missionType, float speed, int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
 
-See [`TASK_VEHICLE_MISSION`](#_0x659427E0EF36BCDE).
+All parameters except ped, vehicle, x, y, z and speed are optional; with `missionType` being only those that don't require a target entity.
+
+If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ## Parameters
-* **ped**: 
-* **vehicle**: 
-* **x**: 
-* **y**: 
-* **z**: 
-* **p5**: 
-* **p6**: 
-* **p7**: 
-* **p8**: 
-* **p9**: 
-* **DriveAgainstTraffic**: 
+* **ped**: The ped to be tasked.
+* **vehicle**: The vehicles' entity handle.
+* **x**: The x coordinate.
+* **y**: The y coordinate.
+* **z**: The z coordinate.
+* **missionType**: The mission type (default is 0) (see [TaskVehicleMission](#_0x659427E0EF36BCDE)).
+* **speed**: The speed in m/s.
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
+* **radius**: The radius of when the task will be completed (default is -1.0f).
+* **straightLineDist**: The distance before the vehicle will drive straight to the target (default is -1.0f).
+* **DriveAgainstTraffic**: Whether the vehicle should drive against traffic (default is false).
 
+## Examples
+
+```lua
+local model = `adder`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId()
+local coords = GetEntityCoords(ped)
+local spawn_coords = coords - GetEntityForwardVector(ped) * 15.0
+local vehicle = CreateVehicle(model, spawn_coords.x, spawn_coords.y, spawn_coords.z, GetEntityHeading(ped), true, false)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskVehicleMissionCoorsTarget(driver, vehicle, coords.x, coords.y, coords.z, 8, 35.0, 786468, -1.0, -1.0, true)
+-- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
+SetPedKeepTask(driver, true)
+```

--- a/TASK/TaskVehicleMissionCoorsTarget.md
+++ b/TASK/TaskVehicleMissionCoorsTarget.md
@@ -28,17 +28,23 @@ If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` f
 ## Examples
 
 ```lua
-local model = `adder`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local vehicle_model = `adder`
+RequestModel(vehicle_model)
+repeat Wait(0) until HasModelLoaded(vehicle_model)
+
 local ped = PlayerPedId()
 local coords = GetEntityCoords(ped)
 local spawn_coords = coords - GetEntityForwardVector(ped) * 15.0
-local vehicle = CreateVehicle(model, spawn_coords.x, spawn_coords.y, spawn_coords.z, GetEntityHeading(ped), true, false)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+local vehicle = CreateVehicle(vehicle_model, spawn_coords.x, spawn_coords.y, spawn_coords.z, GetEntityHeading(ped), true, false)
+SetModelAsNoLongerNeeded(vehicle_model) -- Allow the game engine to clear the model from memory
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local driver = CreatePedInsideVehicle(vehicle, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskVehicleMissionCoorsTarget(driver, vehicle, coords.x, coords.y, coords.z, 8, 35.0, 786468, -1.0, -1.0, true)
 -- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
 SetPedKeepTask(driver, true)

--- a/TASK/TaskVehicleMissionPedTarget.md
+++ b/TASK/TaskVehicleMissionPedTarget.md
@@ -26,16 +26,22 @@ If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` f
 ## Examples
 
 ```lua
-local model = `adder`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
+local vehicle_model = `adder`
+RequestModel(vehicle_model)
+repeat Wait(0) until HasModelLoaded(vehicle_model)
+
 local ped = PlayerPedId()
 local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
-local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
-model = `a_m_m_skater_01`
-RequestModel(model)
-repeat Wait(0) until HasModelLoaded(model)
-local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+local vehicle = CreateVehicle(vehicle_model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+SetModelAsNoLongerNeeded(vehicle_model) -- Allow the game engine to clear the model from memory
+
+local ped_model = `a_m_m_skater_01`
+RequestModel(ped_model)
+repeat Wait(0) until HasModelLoaded(ped_model)
+
+local driver = CreatePedInsideVehicle(vehicle, 0, ped_model, -1, true, false)
+SetModelAsNoLongerNeeded(ped_model) -- Allow the game engine to clear the model from memory
+
 TaskVehicleMissionPedTarget(driver, vehicle, ped, 8, 35.0, 786468, -1.0, -1.0, true)
 -- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
 SetPedKeepTask(driver, true)

--- a/TASK/TaskVehicleMissionPedTarget.md
+++ b/TASK/TaskVehicleMissionPedTarget.md
@@ -16,8 +16,8 @@ See [`TASK_VEHICLE_MISSION`](#_0x659427E0EF36BCDE).
 * **pedTarget**: 
 * **missionType**: 
 * **maxSpeed**: 
-* **drivingStyle**: 
 * **minDistance**: 
 * **p7**: 
 * **DriveAgainstTraffic**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 

--- a/TASK/TaskVehicleMissionPedTarget.md
+++ b/TASK/TaskVehicleMissionPedTarget.md
@@ -5,19 +5,38 @@ ns: TASK
 
 ```c
 // 0x9454528DF15D657A 0xC81C4677
-void TASK_VEHICLE_MISSION_PED_TARGET(Ped ped, Vehicle vehicle, Ped pedTarget, int missionType, float maxSpeed, int drivingStyle, float minDistance, float p7, BOOL DriveAgainstTraffic);
+void TASK_VEHICLE_MISSION_PED_TARGET(Ped ped, Vehicle vehicle, Ped pedTarget, int missionType, float speed, int drivingStyle, float radius, float straightLineDist, BOOL DriveAgainstTraffic);
 ```
 
-See [`TASK_VEHICLE_MISSION`](#_0x659427E0EF36BCDE).
+All parameters except ped, vehicle, pedTarget and speed are optional; with `missionType` being only those that require a target entity.
+
+If you don't want to use a parameter; pass `0` for int parameters, and `-1.0f` for the remaining float parameters.
 
 ## Parameters
-* **ped**: 
-* **vehicle**: 
-* **pedTarget**: 
-* **missionType**: 
-* **maxSpeed**: 
-* **minDistance**: 
-* **p7**: 
-* **DriveAgainstTraffic**: 
+* **ped**: The ped to be tasked.
+* **vehicle**: The vehicles' entity handle.
+* **pedTarget**: The target ped.
+* **missionType**: The mission type (default is 0) (see [TaskVehicleMission](#_0x659427E0EF36BCDE)).
+* **speed**: The speed in m/s.
 * **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
+* **radius**: The radius of when the task will be completed (default is -1.0f).
+* **straightLineDist**: The distance before the vehicle will drive straight to the target (default is -1.0f).
+* **DriveAgainstTraffic**: Whether the vehicle should drive against traffic (default is false).
 
+## Examples
+
+```lua
+local model = `adder`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local ped = PlayerPedId()
+local coords = GetEntityCoords(ped) - GetEntityForwardVector(ped) * 15.0
+local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, GetEntityHeading(ped), true, false)
+model = `a_m_m_skater_01`
+RequestModel(model)
+repeat Wait(0) until HasModelLoaded(model)
+local driver = CreatePedInsideVehicle(vehicle, 0, model, -1, true, false)
+TaskVehicleMissionPedTarget(driver, vehicle, ped, 8, 35.0, 786468, -1.0, -1.0, true)
+-- Mission Type: Flee | Drive Style: DrivingModeAvoidVehiclesReckless
+SetPedKeepTask(driver, true)
+```

--- a/VEHICLE/SetPlaybackToUseAi.md
+++ b/VEHICLE/SetPlaybackToUseAi.md
@@ -12,5 +12,5 @@ Identical to SET_PLAYBACK_TO_USE_AI_TRY_TO_REVERT_BACK_LATER with 0 as arguments
 
 ## Parameters
 * **vehicle**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 

--- a/VEHICLE/SetPlaybackToUseAiTryToRevertBackLater.md
+++ b/VEHICLE/SetPlaybackToUseAiTryToRevertBackLater.md
@@ -15,6 +15,6 @@ Time is number of milliseconds before reverting, zero for indefinitely.
 ## Parameters
 * **vehicle**: 
 * **time**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 * **p3**: 
 

--- a/VEHICLE/StartPlaybackRecordedVehicleUsingAi.md
+++ b/VEHICLE/StartPlaybackRecordedVehicleUsingAi.md
@@ -19,5 +19,5 @@ AI abides by the provided driving style (e.g., stopping at red lights or waiting
 * **recording**: 
 * **script**: 
 * **speed**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 

--- a/VEHICLE/StartPlaybackRecordedVehicleWithFlags.md
+++ b/VEHICLE/StartPlaybackRecordedVehicleWithFlags.md
@@ -19,5 +19,5 @@ time, often zero and capped at 500, is related to SET_PLAYBACK_TO_USE_AI_TRY_TO_
 * **script**: 
 * **flags**: 
 * **time**: 
-* **drivingStyle**: 
+* **drivingStyle**: The driving style (default is 0) (see [SetDriveTaskDrivingStyle](#_0xDACE1BE37D88AF67)).
 


### PR DESCRIPTION
Changed `TaskHeliMission` & `TaskVehicleMission` parameters and enums, as well as updating their descriptions and styling to be in-line with PR #1128. Also fixed some minor typos in `TaskBoatMission` related in the styling of the first two 'Task_Mission' natives.

Added a small description and the driving style flag enum (see [here](https://github.com/scripthookvdotnet/scripthookvdotnet/blob/230c64db471dc821cacbc9b21bd781ea2abc9311/source/scripting_v3/GTA/VehicleAi/Task/VehicleDrivingFlags.cs) and [here](https://github.com/DurtyFree/gta-v-data-dumps/blob/master/drivingStyleFlagValues.json)). This could be used as reference to the description of drivingStyle to the 'Task_Mission' natives.
