### PR TITLE
Update flags for TaskPlayAnim

### DIFF
--- a/TASK/TaskPlayAnim.md
+++ b/TASK/TaskPlayAnim.md
@@ -9,7 +9,6 @@ void TASK_PLAY_ANIM(Ped ped, char* animDictionary, char* animationName, float bl
 ```
 
 [Animations list](https://alexguirre.github.io/animations-list/)  
-[Animation flags](https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3095&search=eScriptedAnimFlags#eScriptedAnimFlags)
 
 ```c
 enum eScriptedAnimFlags

--- a/TASK/TaskPlayAnim.md
+++ b/TASK/TaskPlayAnim.md
@@ -8,65 +8,55 @@ ns: TASK
 void TASK_PLAY_ANIM(Ped ped, char* animDictionary, char* animationName, float blendInSpeed, float blendOutSpeed, int duration, int flag, float playbackRate, BOOL lockX, BOOL lockY, BOOL lockZ);
 ```
 
-[Animations list](https://alexguirre.github.io/animations-list/)
+[Animations list](https://alexguirre.github.io/animations-list/)  
+[Animation flags](https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3095&search=eScriptedAnimFlags#eScriptedAnimFlags)
 
-```
-float blendInSpeed > normal speed is 8.0f
-----------------------  
-float blendOutSpeed > normal speed is 8.0f
-----------------------  
-int duration: time in millisecond  
-----------------------  
--1 _ _ _ _ _ _ _> Default (see flag)  
-0 _ _ _ _ _ _ _ > Not play at all  
-Small value _ _ > Slow down animation speed  
-Other _ _ _ _ _ > freeze player control until specific time (ms) has   
-_ _ _ _ _ _ _ _ _ passed. (No effect if flag is set to be   
-_ _ _ _ _ _ _ _ _ controllable.)  
-int flag:  
-----------------------  
-enum eAnimationFlags  
-{  
- ANIM_FLAG_NORMAL = 0,  
-   ANIM_FLAG_REPEAT = 1,  
-   ANIM_FLAG_STOP_LAST_FRAME = 2,  
-   ANIM_FLAG_UPPERBODY = 16,  
-   ANIM_FLAG_ENABLE_PLAYER_CONTROL = 32,  
-   ANIM_FLAG_CANCELABLE = 120,  
-};  
-Odd number : loop infinitely  
-Even number : Freeze at last frame  
-Multiple of 4: Freeze at last frame but controllable  
-01 to 15 > Full body  
-10 to 31 > Upper body  
-32 to 47 > Full body > Controllable  
-48 to 63 > Upper body > Controllable  
-...  
-001 to 255 > Normal  
-256 to 511 > Garbled  
-...  
-playbackRate:  
-values are between 0.0 and 1.0  
-lockX:    
-0 in most cases 1 for rcmepsilonism8 and rcmpaparazzo_3  
-> 1 for mini@sprunk  
-lockY:  
-0 in most cases   
-1 for missfam5_yoga, missfra1mcs_2_crew_react  
-lockZ:   
-    0 for single player   
-    Can be 1 but only for MP  
+```c
+enum eScriptedAnimFlags
+{
+    AF_LOOPING = 1,
+    AF_HOLD_LAST_FRAME = 2,
+    AF_REPOSITION_WHEN_FINISHED = 4,
+    AF_NOT_INTERRUPTABLE = 8,
+    AF_UPPERBODY = 16,
+    AF_SECONDARY = 32,
+    AF_REORIENT_WHEN_FINISHED = 64,
+    AF_ABORT_ON_PED_MOVEMENT = 128,
+    AF_ADDITIVE = 256,
+    AF_TURN_OFF_COLLISION = 512,
+    AF_OVERRIDE_PHYSICS = 1024,
+    AF_IGNORE_GRAVITY = 2048,
+    AF_EXTRACT_INITIAL_OFFSET = 4096,
+    AF_EXIT_AFTER_INTERRUPTED = 8192,
+    AF_TAG_SYNC_IN = 16384,
+    AF_TAG_SYNC_OUT = 32768,
+    AF_TAG_SYNC_CONTINUOUS = 65536,
+    AF_FORCE_START = 131072,
+    AF_USE_KINEMATIC_PHYSICS = 262144,
+    AF_USE_MOVER_EXTRACTION = 524288,
+    AF_HIDE_WEAPON = 1048576,
+    AF_ENDS_IN_DEAD_POSE = 2097152,
+    AF_ACTIVATE_RAGDOLL_ON_COLLISION = 4194304,
+    AF_DONT_EXIT_ON_DEATH = 8388608,
+    AF_ABORT_ON_WEAPON_DAMAGE = 16777216,
+    AF_DISABLE_FORCED_PHYSICS_UPDATE = 33554432,
+    AF_PROCESS_ATTACHMENTS_ON_START = 67108864,
+    AF_EXPAND_PED_CAPSULE_FROM_SKELETON = 134217728,
+    AF_USE_ALTERNATIVE_FP_ANIM = 268435456,
+    AF_BLENDOUT_WRT_LAST_FRAME = 536870912,
+    AF_USE_FULL_BLENDING = 1073741824
+}
 ```
 
 ## Parameters
-* **ped**: 
-* **animDictionary**: 
-* **animationName**: 
-* **blendInSpeed**: 
-* **blendOutSpeed**: 
-* **duration**: 
-* **flag**: 
-* **playbackRate**: 
+* **ped**: The ped you want to play the animation
+* **animDictionary**: The animation dictionary
+* **animationName**: The animation name
+* **blendInSpeed**: The speed at which the animation blends in. Lower is slower and higher is faster, 1.0 is normal, 8.0 is basically instant
+* **blendOutSpeed**: The speed at which the animation blends out. Lower is slower and higher is faster, 1.0 is normal, 8.0 is basically instant
+* **duration**: The duration of the animation in milliseconds. -1 will play the animation until canceled
+* **flag**: The animation flags (see enum)
+* **playbackRate**: The playback rate (between 0.0 and 1.0)
 * **lockX**: 
 * **lockY**: 
 * **lockZ**: 

--- a/TASK/TaskPlayAnimAdvanced.md
+++ b/TASK/TaskPlayAnimAdvanced.md
@@ -5,7 +5,7 @@ ns: TASK
 
 ```c
 // 0x83CDB10EA29B370B 0x3DDEB0E6
-void TASK_PLAY_ANIM_ADVANCED(Ped ped, char* animDict, char* animName, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float animEnterSpeed, float animExitSpeed, int duration, Any flag, float animTime, Any p14, Any p15);
+void TASK_PLAY_ANIM_ADVANCED(Ped ped, char* animDictionary, char* animationName, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float blendInSpeed, float blendOutSpeed, int duration, Any flag, float animTime, Any p14, Any p15);
 ```
 
 
@@ -16,19 +16,19 @@ It's similar to the one above, except the first 6 floats let you specify the ini
 
 
 ## Parameters
-* **ped**: The target ped
-* **animDict**: Name of the animation dictionary
-* **animName**: Name of the animation
+* **ped**: The ped you want to play the animation
+* **animDictionary**: The animation dictionary
+* **animationName**: The animation name
 * **posX**: Initial X position of the task
 * **posY**: Initial Y position of the task
 * **posZ**: Initial Z position of the task
-* **rotX**: Initial X rotation of the task, doesn't seem to have any effect
-* **rotY**: Initial Y rotation of the task, doesn't seem to have any effect
+* **rotX**: Initial X rotation of the task
+* **rotY**: Initial Y rotation of the task
 * **rotZ**: Initial Z rotation of the task
-* **animEnterSpeed**: Adjust character speed to fully enter animation
-* **animExitSpeed**: Adjust character speed to fully exit animation (useless `ClearPedTasksImmediately()` is called)
-* **duration**: Time in milliseconds
-* **flag**: 
+* **blendInSpeed**: The speed at which the animation blends in. Lower is slower and higher is faster, 1.0 is normal, 8.0 is basically instant
+* **blendOutSpeed**: The speed at which the animation blends out. Lower is slower and higher is faster, 1.0 is normal, 8.0 is basically instant
+* **duration**: The duration of the animation in milliseconds. -1 will play the animation until canceled
+* **flag**: See [`TASK_PLAY_ANIM`](#_0xEA47FE3719165B94)
 * **animTime**: Value between 0.0 and 1.0, lets you start an animation from the given point
 * **p14**: 
 * **p15**: 

--- a/TASK/TaskPlayAnimAdvanced.md
+++ b/TASK/TaskPlayAnimAdvanced.md
@@ -8,12 +8,9 @@ ns: TASK
 void TASK_PLAY_ANIM_ADVANCED(Ped ped, char* animDictionary, char* animationName, float posX, float posY, float posZ, float rotX, float rotY, float rotZ, float blendInSpeed, float blendOutSpeed, int duration, Any flag, float animTime, Any p14, Any p15);
 ```
 
-
-It's similar to the one above, except the first 6 floats let you specify the initial position and rotation of the task. (Ped gets teleported to the position).
-
+Similar in functionality to [`TASK_PLAY_ANIM`](#_0xEA47FE3719165B94), except the position and rotation parameters let you specify the initial position and rotation of the task. The ped is teleported to the position specified.
 
 [Animations list](https://alexguirre.github.io/animations-list/)
-
 
 ## Parameters
 * **ped**: The ped you want to play the animation


### PR DESCRIPTION
I've been searching for the animation flags in alexguirre's rage parser dump [here](https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3095). I found [eScriptedAnimFlags](https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3095&search=eScriptedAnimFlags#eScriptedAnimFlags) which from my testing seems to line up with what i see in game when using said flag.

Previously known:  
1 = Looping
2 = Stop last frame
16 = Upperbody
32 = Allow player control

lines up with the enum i found. I also tested a few new flags from the enum like "AF_HIDE_WEAPON" (1048576) which as expected hid any equipped weapon while the animation was active, leading me to believe these are the animation flags used by the game.