### PR TITLE
tweak(natives/hud): add description and example for SET_BLIP_COLOUR

### DIFF
--- a/HUD/SetBlipColour.md
+++ b/HUD/SetBlipColour.md
@@ -9,5 +9,18 @@ void SET_BLIP_COLOUR(Blip blip, int color);
 ```
 
 ## Parameters
-* **blip**: 
+* **blip**: A blip handle
 * **color**: See [blip colors here](https://docs.fivem.net/docs/game-references/blips/#blip-colors)
+
+Sets the color of a blip. The color can also be a hex if you want a color that's not included in the list above.
+
+## Examples
+```lua
+local coords = GetEntityCoords(PlayerPedId())
+local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+
+SetBlipColour(blip, 1) -- Sets the color to red (see list above)
+
+-- You can also use a hex like so:
+SetBlipColour(blip, 0x3A7F3AFF) -- Our custom green
+```

--- a/HUD/SetBlipColour.md
+++ b/HUD/SetBlipColour.md
@@ -8,7 +8,6 @@ ns: HUD
 void SET_BLIP_COLOUR(Blip blip, int color);
 ```
 
-
 ## Parameters
 * **blip**: The blip handle to set the color of
 * **color**: This can be a hex color code, or a [blip color](https://docs.fivem.net/docs/game-references/blips/#blip-colors).

--- a/HUD/SetBlipColour.md
+++ b/HUD/SetBlipColour.md
@@ -8,11 +8,10 @@ ns: HUD
 void SET_BLIP_COLOUR(Blip blip, int color);
 ```
 
-Sets the color of a blip. The color can also be a hex if you want a color that's not included in the list above.
 
 ## Parameters
-* **blip**: A blip handle
-* **color**: See [blip colors here](https://docs.fivem.net/docs/game-references/blips/#blip-colors)
+* **blip**: The blip handle to set the color of
+* **color**: This can be a hex color code, or a [blip color](https://docs.fivem.net/docs/game-references/blips/#blip-colors).
 
 ## Examples
 ```lua

--- a/HUD/SetBlipColour.md
+++ b/HUD/SetBlipColour.md
@@ -8,11 +8,11 @@ ns: HUD
 void SET_BLIP_COLOUR(Blip blip, int color);
 ```
 
+Sets the color of a blip. The color can also be a hex if you want a color that's not included in the list above.
+
 ## Parameters
 * **blip**: A blip handle
 * **color**: See [blip colors here](https://docs.fivem.net/docs/game-references/blips/#blip-colors)
-
-Sets the color of a blip. The color can also be a hex if you want a color that's not included in the list above.
 
 ## Examples
 ```lua


### PR DESCRIPTION
Adds a description to the native including info about the ability to pass a hex into the second parameter. I also included an example as it was missing. The example code produces the following: https://imgur.com/a/jW52jYd

This should follow the contributions guideline format, let me know if anything needs to be changed.