### PR TITLE
tweak(natives): use shorthand name for codeblocks throughout the repo

### DIFF
--- a/CAM/IsScriptGlobalShaking.md
+++ b/CAM/IsScriptGlobalShaking.md
@@ -27,7 +27,7 @@ print(IsScriptGlobalShaking())
 // Print whether a global camera shake is currently active
 console.log(IsScriptGlobalShaking());
 ```
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Print whether a global camera shake is currently active

--- a/CAM/StopScriptGlobalShaking.md
+++ b/CAM/StopScriptGlobalShaking.md
@@ -31,7 +31,7 @@ if (IsScriptGlobalShaking()) {
     StopScriptGlobalShaking(false);
 }
 ```
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Stops the currently active global camera shake with a gradual fade out

--- a/ENTITY/SetEntityAlpha.md
+++ b/ENTITY/SetEntityAlpha.md
@@ -25,7 +25,7 @@ SetEntityAlpha(PlayerPedId(), 51, false)
 SetEntityAlpha(PlayerPedId(), 51, false);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 // ...
 

--- a/HUD/EndTextCommandDisplayHelp.md
+++ b/HUD/EndTextCommandDisplayHelp.md
@@ -25,8 +25,6 @@ AddTextEntry('HelpMsg', 'Press ~INPUT_CONTEXT~ to do something.')
 BeginTextCommandDisplayHelp('HelpMsg')
 EndTextCommandDisplayHelp(0, false, true, -1)
 
-
-
 -- Shows a floating help text which uses FLOATING_HELP_TEXT_1 hud component.
 AddTextEntry('FloatingHelpText', 'Press E to show respect.')
 SetFloatingHelpTextWorldPosition(0, vector3(100, 100, 100))

--- a/HUD/EndTextCommandThefeedPostTicker.md
+++ b/HUD/EndTextCommandThefeedPostTicker.md
@@ -15,16 +15,16 @@ Example output preview:
 ![](https://i.imgur.com/TJvqkYq.png)
 
 
-## Examples
-```lua
-BeginTextCommandThefeedPost("STRING")
-AddTextComponentSubstringPlayerName("Hello " .. GetPlayerName(PlayerId()) .. ".")
-EndTextCommandThefeedPostTicker(true, true)
-```
-
 ## Parameters
 * **isImportant**: Makes the notification flash on the screen.
 * **bHasTokens**: Makes the notification appear in the "Pause Menu > Info/Brief > Notifications" section.
 
 ## Return value
 The notification handle.
+
+## Examples
+```lua
+BeginTextCommandThefeedPost("STRING")
+AddTextComponentSubstringPlayerName("Hello " .. GetPlayerName(PlayerId()) .. ".")
+EndTextCommandThefeedPostTicker(true, true)
+```

--- a/MISC/ClearAreaOfCops.md
+++ b/MISC/ClearAreaOfCops.md
@@ -10,12 +10,6 @@ void CLEAR_AREA_OF_COPS(float x, float y, float z, float radius, cs_type(int) BO
 
 Clears an area of cops at the given coordinates and radius.
 
-## Examples
-```lua
--- Clear the area, do also create an event
-ClearAreaOfCops(0.0, 0.0, 0.0, 10000.0, true)
-```
-
 ## Parameters
 * **x**: The x coordinate of where to clear cops.
 * **y**: The y coordinate of where to clear cops.
@@ -23,3 +17,8 @@ ClearAreaOfCops(0.0, 0.0, 0.0, 10000.0, true)
 * **radius**: The area radius to clear cops.
 * **createNetEvent**: specifies whether a `CClearAreaEvent` event of should be created for online use.
 
+## Examples
+```lua
+-- Clear the area, do also create an event
+ClearAreaOfCops(0.0, 0.0, 0.0, 10000.0, true)
+```

--- a/MISC/GetGroundZAndNormalFor_3dCoord.md
+++ b/MISC/GetGroundZAndNormalFor_3dCoord.md
@@ -50,7 +50,7 @@ if (success) {
 }
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 float x = 100.0f, y = -200.0f, z = 50.0f;

--- a/MISC/GetLinePlaneIntersection.md
+++ b/MISC/GetLinePlaneIntersection.md
@@ -82,7 +82,7 @@ if (success) {
 }
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Define the line segment with start and end points

--- a/OBJECT/DeleteObject.md
+++ b/OBJECT/DeleteObject.md
@@ -52,7 +52,7 @@ if (IsEntityAMissionEntity(object)) {
 DeleteObject(object);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 int playerPed = PlayerPedId();

--- a/PLAYER/SetPlayerCanDoDriveBy.md
+++ b/PLAYER/SetPlayerCanDoDriveBy.md
@@ -12,12 +12,11 @@ Sets whether the player is able to do drive-bys in vehicle (shooting & aiming in
 
 This is a toggle, it does not have to be ran every frame.
 
-Example:
-```lua
-SetPlayerCanDoDriveBy(PlayerId(), false)
-```
-
 ## Parameters
 * **player**: The player to target.
 * **toggle**: If set to false, disables the players ability to do drive bys.
 
+## Example
+```lua
+SetPlayerCanDoDriveBy(PlayerId(), false)
+```

--- a/STREAMING/GetPlayerSwitchState.md
+++ b/STREAMING/GetPlayerSwitchState.md
@@ -22,7 +22,7 @@ if stateSwitch == 5 then
 end
 ```
 
-```javascript
+```js
 const stateSwitch = GetPlayerSwitchState();
 if (stateSwitch == 5) {
     // Player is in the air
@@ -31,7 +31,7 @@ if (stateSwitch == 5) {
 }
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 int stateSwitch = GetPlayerSwitchState();

--- a/STREAMING/SwitchToMultiFirstpart.md
+++ b/STREAMING/SwitchToMultiFirstpart.md
@@ -38,7 +38,7 @@ if (!IsPlayerSwitchInProgress()) {
 }
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Check if the player is in a Switch "state"

--- a/STREAMING/SwitchToMultiSecondpart.md
+++ b/STREAMING/SwitchToMultiSecondpart.md
@@ -25,7 +25,7 @@ RegisterCommand("switchPlayer", function()
 end, false)
 ```
 
-```javascript
+```js
 RegisterCommand("switchPlayer", () => {
     if (IsPlayerSwitchInProgress()) return;
     const ped = PlayerPedId();
@@ -35,7 +35,7 @@ RegisterCommand("switchPlayer", () => {
 }, false);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 RegisterCommand("switchPlayer", new Action<int, List<object>, string>(async (user, args, raw) =>
 {

--- a/VEHICLE/FullyChargeNitrous.md
+++ b/VEHICLE/FullyChargeNitrous.md
@@ -36,7 +36,7 @@ SetOverrideNitrousLevel(vehicle, true, 1.5, 2.0, 0.5, false)
 FullyChargeNitrous(vehicle)
 ```
 
-```javascript
+```js
 // Retrieve the player ped
 const playerPed = PlayerPedId();
 
@@ -53,7 +53,7 @@ SetOverrideNitrousLevel(vehicle, true, 1.5, 2.0, 0.5, false);
 FullyChargeNitrous(vehicle);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Retrieve the player ped

--- a/VEHICLE/GetRemainingNitrousDuration.md
+++ b/VEHICLE/GetRemainingNitrousDuration.md
@@ -40,7 +40,7 @@ CreateThread(function()
 end)
 ```
 
-```javascript
+```js
 setTick(async () => {
     // Retrieve the player ped.
     let playerPed = PlayerPedId();

--- a/VEHICLE/GetVehicleFlightNozzlePosition.md
+++ b/VEHICLE/GetVehicleFlightNozzlePosition.md
@@ -29,6 +29,21 @@ end
 
 ```
 
+
+```js
+let vehicle = GetVehiclePedIsIn(PlayerPedId(), false);
+
+if (GetVehicleFlightNozzlePosition(vehicle) === 0.0) {
+    console.log("Flying normally!");
+}
+else if (GetVehicleFlightNozzlePosition(vehicle) === 1.0) {
+    console.log("Flying in VTOL mode!");
+}
+else {
+    console.log("Currently switching hover mode!");
+}
+```
+
 ```cs
 int vehicle = GetVehiclePedIsIn(PlayerPedId(), false);
 
@@ -43,19 +58,5 @@ else if (GetVehicleFlightNozzlePosition(vehicle) == 1f)
 else
 {
     Debug.WriteLine("Currently switching hover mode!");
-}
-```
-
-```js
-let vehicle = GetVehiclePedIsIn(PlayerPedId(), false);
-
-if (GetVehicleFlightNozzlePosition(vehicle) === 0.0) {
-    console.log("Flying normally!");
-}
-else if (GetVehicleFlightNozzlePosition(vehicle) === 1.0) {
-    console.log("Flying in VTOL mode!");
-}
-else {
-    console.log("Currently switching hover mode!");
 }
 ```

--- a/VEHICLE/IsNitrousActive.md
+++ b/VEHICLE/IsNitrousActive.md
@@ -36,7 +36,7 @@ if vehicle == 0 then return end
 print(IsNitrousActive(vehicle))
 ```
 
-```javascript
+```js
 // Retrieve the player ped
 const playerPed = PlayerPedId();
 

--- a/VEHICLE/SetDisableHeliExplodeFromBodyDamage.md
+++ b/VEHICLE/SetDisableHeliExplodeFromBodyDamage.md
@@ -34,7 +34,7 @@ if (helicopter == 0) or (not IsThisModelAHeli(GetEntityModel(helicopter))) then 
 SetDisableHeliExplodeFromBodyDamage(helicopter, true)
 ```
 
-```javascript
+```js
 // Retrieve the player ped.
 const playerPed = PlayerPedId();
 
@@ -48,7 +48,7 @@ if (helicopter === 0 || !IsThisModelAHeli(GetEntityModel(helicopter))) return;
 SetDisableHeliExplodeFromBodyDamage(helicopter, true);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Retrieve the player ped.

--- a/VEHICLE/SetHeliTailBoomCanBreakOff.md
+++ b/VEHICLE/SetHeliTailBoomCanBreakOff.md
@@ -27,14 +27,14 @@ if heli == 0 or GetVehicleType(heli) ~= "heli" then return end
 SetHeliTailBoomCanBreakOff(heli, true)
 ```
 
-```javascript
+```js
 const heli = GetVehiclePedIsIn(PlayerPedId(), false);
 if (heli === 0 || GetVehicleType(heli) !== "heli") return;
 
 SetHeliTailBoomCanBreakOff(heli, true);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 int heli = GetVehiclePedIsIn(PlayerPedId(), false);

--- a/VEHICLE/SetNitrousIsActive.md
+++ b/VEHICLE/SetNitrousIsActive.md
@@ -35,7 +35,7 @@ if vehicle == 0 then return end
 SetNitrousIsActive(vehicle, true)
 ```
 
-```javascript
+```js
 // Retrieve the player ped
 const playerPed = PlayerPedId();
 
@@ -49,7 +49,7 @@ if (vehicle == 0) return;
 SetNitrousIsActive(vehicle, true);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Retrieve the player ped

--- a/VEHICLE/SetOverrideNitrousLevel.md
+++ b/VEHICLE/SetOverrideNitrousLevel.md
@@ -39,7 +39,7 @@ if vehicle == 0 then return end
 SetOverrideNitrousLevel(vehicle, true, 100, 100, 99999999999, false);
 ```
 
-```javascript
+```js
 // Retrieve the player ped
 const playerPed = PlayerPedId();
 
@@ -53,7 +53,7 @@ if (vehicle == 0) return;
 SetOverrideNitrousLevel(vehicle, true, 100, 100, 99999999999, false);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Retrieve the player ped

--- a/VEHICLE/SetVehicleUseHornButtonForNitrous.md
+++ b/VEHICLE/SetVehicleUseHornButtonForNitrous.md
@@ -34,7 +34,7 @@ if vehicle == 0 then return end
 SetVehicleUseHornButtonForNitrous(vehicle, true)
 ```
 
-```javascript
+```js
 // Retrieve the player ped
 const playerPed = PlayerPedId();
 
@@ -48,7 +48,7 @@ if (vehicle == 0) return;
 SetVehicleUseHornButtonForNitrous(vehicle, true);
 ```
 
-```csharp
+```cs
 using static CitizenFX.Core.Native.API;
 
 // Retrieve the player ped


### PR DESCRIPTION
Also moves examples to the very bottom on some natives that had it above.