### PR TITLE
feat(natives/ped): improve documentation for SET_PED_MIN_GROUND_TIME_FOR_STUNGUN

### DIFF
--- a/PED/SetPedMinGroundTimeForStungun.md
+++ b/PED/SetPedMinGroundTimeForStungun.md
@@ -8,11 +8,84 @@ ns: PED
 void SET_PED_MIN_GROUND_TIME_FOR_STUNGUN(Ped ped, int ms);
 ```
 
-```
-Ped will stay on the ground after being stunned for at lest ms time. (in milliseconds)  
-```
+Overwrites the minimum time the ped will stay on the ground for after being stunned. Setting this while the ped is stunned will not alter the duration of the current stun (but will still effect future stunns).
+
+Unlike what this native's name suggests, it also effects the time for other "weapons", such as WEAPON_ELECTRIC_FENCE.
+
+Passing a negative value (usually -1) into the second parameter (ms) will reset the ground time back to default (ground time will then depend on the weapon that inflicts the stun).
 
 ## Parameters
-* **ped**: 
-* **ms**: 
+* **ped**: The ped to set the min ground time for
+* **ms**: The minimum time in milliseconds
 
+## Examples
+```lua
+-- This sets the minimum stun ground time for the player's ped to 10 seconds (and re-applies it if the player's ped changes)
+
+local currentPed = 0
+CreateThread(function()
+    while true do
+        local playerPed = PlayerPedId()
+
+        -- Checks if the player ped has changed
+        if currentPed ~= playerPed then
+            currentPed = playerPed
+
+            -- Sets the minimum stun ground time to 10 seconds
+            SetPedMinGroundTimeForStungun(currentPed, 10000)
+        end
+
+        Wait(1000)
+    end
+end)
+```
+
+```js
+// This sets the minimum stun ground time for the player's ped to 10 seconds (and re-applies it if the player's ped changes)
+
+let currentPed = 0;
+Delay = (ms) => new Promise(res => setTimeout(res, ms));
+
+setTick(async () => {
+    const playerPed = PlayerPedId();
+
+    // Checks if the player ped has changed
+    if (currentPed != playerPed) {
+        currentPed = playerPed;
+
+        // Sets the minimum stun ground time to 10 seconds
+        SetPedMinGroundTimeForStungun(currentPed, 10000);
+    };
+
+    await Delay(1000);
+});
+```
+
+```cs
+// This sets the minimum stun ground time for the player's ped to 10 seconds (and re-applies it if the player's ped changes)
+
+using static CitizenFX.Core.Native.API;
+// ...
+
+private int currentPed = 0;
+
+public Main() 
+{
+    Tick += OnTick;
+}
+
+private async Task OnTick()
+{
+    var playerPed = Game.PlayerPed.Handle;
+
+    // Checks if the player ped has changed
+    if (currentPed != playerPed)
+    {
+        currentPed = playerPed;
+
+        // Sets the minimum stun ground time to 10 seconds
+        SetPedMinGroundTimeForStungun(currentPed, 10000);
+    }
+
+    await BaseScript.Delay(1000);
+}

--- a/PED/SetPedMinGroundTimeForStungun.md
+++ b/PED/SetPedMinGroundTimeForStungun.md
@@ -10,9 +10,9 @@ void SET_PED_MIN_GROUND_TIME_FOR_STUNGUN(Ped ped, int minTimeInMs);
 
 Overwrites the minimum time the ped will stay on the ground for after being stunned. Setting this while the ped is stunned will not alter the duration of the current stun but will still effect future stuns.
 
-Unlike what this native's name suggests, it also effects the time for other "weapons", such as WEAPON_ELECTRIC_FENCE.
-
 Passing -1 into the second parameter `minTimeInMs` will reset the modifier, making it use the weapons original `DamageTime` as the stun duration (see `update/update.rpf/common/data/ai/weapons.meta`)
+
+**NOTE**: Unlike what the native name implies, this works on any weapon that has its `DamageType` in the `weapons.meta` set to `ELECTRIC`.
 
 ## Parameters
 * **ped**: The ped to set the min ground time for

--- a/PED/SetPedMinGroundTimeForStungun.md
+++ b/PED/SetPedMinGroundTimeForStungun.md
@@ -44,21 +44,18 @@ end)
 // This sets the minimum stun ground time for the player's ped to 10 seconds (and re-applies it if the player's ped changes)
 
 let currentPed = 0;
-Delay = (ms) => new Promise(res => setTimeout(res, ms));
 
-setTick(async () => {
+setInterval(() => {
     const playerPed = PlayerPedId();
 
     // Checks if the player ped has changed
-    if (currentPed != playerPed) {
+    if (currentPed !== playerPed) {
         currentPed = playerPed;
 
         // Sets the minimum stun ground time to 10 seconds
         SetPedMinGroundTimeForStungun(currentPed, 10000);
     };
-
-    await Delay(1000);
-});
+}, 1000);
 ```
 
 ```cs

--- a/PED/SetPedMinGroundTimeForStungun.md
+++ b/PED/SetPedMinGroundTimeForStungun.md
@@ -5,18 +5,18 @@ ns: PED
 
 ```c
 // 0xFA0675AB151073FA 0x2F0D0973
-void SET_PED_MIN_GROUND_TIME_FOR_STUNGUN(Ped ped, int ms);
+void SET_PED_MIN_GROUND_TIME_FOR_STUNGUN(Ped ped, int minTimeInMs);
 ```
 
-Overwrites the minimum time the ped will stay on the ground for after being stunned. Setting this while the ped is stunned will not alter the duration of the current stun (but will still effect future stunns).
+Overwrites the minimum time the ped will stay on the ground for after being stunned. Setting this while the ped is stunned will not alter the duration of the current stun but will still effect future stuns.
 
 Unlike what this native's name suggests, it also effects the time for other "weapons", such as WEAPON_ELECTRIC_FENCE.
 
-Passing a negative value (usually -1) into the second parameter (ms) will reset the ground time back to default (ground time will then depend on the weapon that inflicts the stun).
+Passing -1 into the second parameter `minTimeInMs` will reset the modifier, making it use the weapons original `DamageTime` as the stun duration (see `update/update.rpf/common/data/ai/weapons.meta`)
 
 ## Parameters
 * **ped**: The ped to set the min ground time for
-* **ms**: The minimum time in milliseconds
+* **minTimeInMs**: The minimum time the stun should last in milliseconds.
 
 ## Examples
 ```lua

--- a/PED/SetPedMinGroundTimeForStungun.md
+++ b/PED/SetPedMinGroundTimeForStungun.md
@@ -76,7 +76,7 @@ public Main()
 
 private async Task OnTick()
 {
-    var playerPed = Game.PlayerPed.Handle;
+    int playerPed = PlayerPedId();
 
     // Checks if the player ped has changed
     if (currentPed != playerPed)


### PR DESCRIPTION
Improves the documentation for SET_PED_MIN_GROUND_TIME_FOR_STUNGUN by adding a more detailed description and examples.

The included example is a simple loop that sets the minimum ground time to 10 seconds whenever the player's ped changes.