### PR TITLE
add(docs/natives): 2 new weather types + remove link chain

### DIFF
--- a/MISC/GetNextWeatherTypeHashName.md
+++ b/MISC/GetNextWeatherTypeHashName.md
@@ -9,6 +9,6 @@ aliases: ["_GET_NEXT_WEATHER_TYPE"]
 Hash GET_NEXT_WEATHER_TYPE_HASH_NAME();
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Return value

--- a/MISC/GetPrevWeatherTypeHashName.md
+++ b/MISC/GetPrevWeatherTypeHashName.md
@@ -9,6 +9,6 @@ aliases: ["_GET_PREV_WEATHER_TYPE"]
 Hash GET_PREV_WEATHER_TYPE_HASH_NAME();
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Return value

--- a/MISC/GetWeatherTypeTransition.md
+++ b/MISC/GetWeatherTypeTransition.md
@@ -8,7 +8,7 @@ ns: MISC
 void _GET_WEATHER_TYPE_TRANSITION(Hash* weatherType1, Hash* weatherType2, float* percentWeather2);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Parameters
 * **weatherType1**: 

--- a/MISC/IsNextWeatherType.md
+++ b/MISC/IsNextWeatherType.md
@@ -8,7 +8,7 @@ ns: MISC
 BOOL IS_NEXT_WEATHER_TYPE(char* weatherType);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Parameters
 * **weatherType**: 

--- a/MISC/IsPrevWeatherType.md
+++ b/MISC/IsPrevWeatherType.md
@@ -8,7 +8,7 @@ ns: MISC
 BOOL IS_PREV_WEATHER_TYPE(char* weatherType);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Parameters
 * **weatherType**: 

--- a/MISC/SetOverrideWeather.md
+++ b/MISC/SetOverrideWeather.md
@@ -8,7 +8,7 @@ ns: MISC
 void SET_OVERRIDE_WEATHER(char* weatherType);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Parameters
 * **weatherType**: 

--- a/MISC/SetWeatherTypeNow.md
+++ b/MISC/SetWeatherTypeNow.md
@@ -32,6 +32,8 @@ NativeDB Introduced: v323
 - BLIZZARD
 - HALLOWEEN
 - NEUTRAL
+- RAIN_HALLOWEEN
+- SNOW_HALLOWEEN
 
 ## Parameters
 * **weatherType**: The weather type to set. This should be one of the predefined weather type strings.

--- a/MISC/SetWeatherTypeOvertimePersist.md
+++ b/MISC/SetWeatherTypeOvertimePersist.md
@@ -9,7 +9,7 @@ aliases: ["_SET_WEATHER_TYPE_OVER_TIME"]
 void SET_WEATHER_TYPE_OVERTIME_PERSIST(char* weatherType, float time);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ## Parameters
 * **weatherType**: The weather type to override to.

--- a/MISC/SetWeatherTypePersist.md
+++ b/MISC/SetWeatherTypePersist.md
@@ -17,4 +17,4 @@ NativeDB Introduced: v323
 ```
 
 ## Parameters
-* **weatherType**: The weather type to be set as persistent. Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for a list of weather type strings.
+* **weatherType**: The weather type to be set as persistent. Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for a list of weather type strings.

--- a/MISC/SetWeatherTypeTransition.md
+++ b/MISC/SetWeatherTypeTransition.md
@@ -8,7 +8,7 @@ ns: MISC
 void _SET_WEATHER_TYPE_TRANSITION(Hash weatherType1, Hash weatherType2, float percentWeather2);
 ```
 
-Refer to [`SET_WEATHER_TYPE_NOW_PERSIST`](#_0xED712CA327900C8A) for weather types.
+Refer to [`SET_WEATHER_TYPE_NOW`](#_0x29B487C359E19889) for weather types.
 
 ```
 Mixes two weather types. If percentWeather2 is set to 0.0f, then the weather will be entirely of weatherType1, if it is set to 1.0f it will be entirely of weatherType2. If it's set somewhere in between, there will be a mixture of weather behaviors. To test, try this in the RPH console, and change the float to different values between 0 and 1:  


### PR DESCRIPTION
With the b3258 game build, 2 new weather types were introduced, RAIN_HALLOWEEN and SNOW_HALLOWEEN - https://streamable.com/mcrfzu.

For natives which direct the user to [SET_WEATHER_TYPE_NOW_PERSIST](https://docs.fivem.net/natives/?_0xED712CA327900C8A) for weather types, it will now send the user directly to [SET_WEATHER_TYPE_NOW](https://docs.fivem.net/natives/?_0x29B487C359E19889) instead of having to go through (the empty) [SET_WEATHER_TYPE_NOW_PERSIST](https://docs.fivem.net/natives/?_0xED712CA327900C8A) native.