### PR TITLE
Create SetAircraftPilotSkillNoiseScalar

### DIFF
--- a/VEHICLE/SetAircraftPilotSkillNoiseScalar
+++ b/VEHICLE/SetAircraftPilotSkillNoiseScalar
@@ -1,0 +1,17 @@
+---
+ns: VEHICLE
+---
+## SET_AIRCRAFT_PILOT_SKILL_NOISE_SCALAR
+
+```c
+// 0xE5810AC70602F2F5 0xB6BE07E0
+void SET_AIRCRAFT_PILOT_SKILL_NOISE_SCALAR(Vehicle vehicle, FLOAT scalar);
+```
+
+```
+Appears to make the helicopter engine quieter the higher p2 is. 0.0 = lowest, 1.0 = highest.
+```
+
+## Parameters
+* **vehicle**: 
+* **scalar**: 


### PR DESCRIPTION
Added information about an as-of-yet documented native surrounding aircraft noise.

An example of this native in use is found in docks_heistb.c in func_304, which I have pasted below. Depending on the flying skill stat of Michael during The Merryweather Heist in the offshore approach, the helicopter's noise level will be adjusted.

```c
void func_304(int iParam0, int iParam1)
{
	if (VEHICLE::IS_VEHICLE_DRIVEABLE(iParam0, false))
	{
		if (iParam1 >= 90)
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 0.75f);
		}
		else if (iParam1 >= 80)
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 0.8f);
		}
		else if (iParam1 >= 70)
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 0.85f);
		}
		else if (iParam1 >= 60)
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 0.9f);
		}
		else if (iParam1 >= 50)
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 0.95f);
		}
		else
		{
			VEHICLE::_0xE5810AC70602F2F5(iParam0, 1f);
		}
	}
}
```