### PR TITLE
Update DataarrayAddDict.md  - Inform the users about the native ban.

### DIFF
--- a/DATAFILE/DataarrayAddDict.md
+++ b/DATAFILE/DataarrayAddDict.md
@@ -8,7 +8,7 @@ aliases: ["_ARRAY_VALUE_ADD_OBJECT"]
 // 0x6889498B3E19C797 0xC174C71B
 Any* DATAARRAY_ADD_DICT(Any* arrayData);
 ```
-
+This native is currently banned. Reference: https://github.com/citizenfx/fivem/blob/c95b323ade0432603f67cc73d23460c517822e28/code/components/rage-scripting-five/src/scrEngine.cpp#34
 
 ## Parameters
 * **arrayData**: 


### PR DESCRIPTION
I'd like to inform the users about the native ban. According to the https://github.com/citizenfx/fivem/blob/c95b323ade0432603f67cc73d23460c517822e28/code/components/rage-scripting-five/src/scrEngine.cpp these natives are banned, and the developers are not able to use it them.