### PR TITLE
Add description for MODEL_HIDE natives and document last parameter

### DIFF
--- a/ENTITY/CreateModelHide.md
+++ b/ENTITY/CreateModelHide.md
@@ -5,20 +5,19 @@ ns: ENTITY
 
 ```c
 // 0x8A97BCA30A0CE478 0x7BD5CF2F
-void CREATE_MODEL_HIDE(float x, float y, float z, float radius, Hash model, BOOL p5);
+void CREATE_MODEL_HIDE(float x, float y, float z, float radius, Hash model, BOOL surviveMapReload);
 ```
 
-```
-p5 = sets as true in scripts  
-Same as the comment for CREATE_MODEL_SWAP unless for some reason p5 affects it this only works with objects as well.  
-Network players do not see changes done with this.  
-```
+Hides all objects of the specified model intersecting a sphere centered at (x, y, z) with the given radius.
+Network players do not see changes done with this.
+Use [`CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS`](#_0x3A52AE588830BF7F) if you only want to hide map objects and exclude those created by scripts.
+Use [`REMOVE_MODEL_HIDE`](#_0xD9E3006FB3CBD765) to make hidden objects visible again.
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
-* **radius**: 
-* **model**: 
-* **p5**: 
+* **x**: X Coordinate of the hiding sphere center.
+* **y**: Y Coordinate of the hiding sphere center.
+* **z**: Z Coordinate of the hiding sphere center.
+* **radius**: Radius of the hiding sphere.
+* **model**: The object's model hash to hide.
+* **surviveMapReload**: If false, only currently loaded objects are hidden. If their map unloads (e.g. by moving away) and reloads, the objects will reappear.
 

--- a/ENTITY/CreateModelHideExcludingScriptObjects.md
+++ b/ENTITY/CreateModelHideExcludingScriptObjects.md
@@ -5,15 +5,18 @@ ns: ENTITY
 
 ```c
 // 0x3A52AE588830BF7F 0x07AAF22C
-void CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS(float x, float y, float z, float radius, Hash model, BOOL p5);
+void CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS(float x, float y, float z, float radius, Hash model, BOOL surviveMapReload);
 ```
 
+Hides all objects of the specified model intersecting a sphere centered at (x, y, z) with the given radius, excluding objects created by scripts.
+Network players do not see changes done with this.
+Use [`REMOVE_MODEL_HIDE`](#_0xD9E3006FB3CBD765) to make hidden objects visible again.
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
-* **radius**: 
-* **model**: 
-* **p5**: 
+* **x**: X Coordinate of the hiding sphere center.
+* **y**: Y Coordinate of the hiding sphere center.
+* **z**: Z Coordinate of the hiding sphere center.
+* **radius**: Radius of the hiding sphere.
+* **model**: The object's model hash to hide.
+* **surviveMapReload**: If false, only currently loaded objects are hidden. If their map unloads (e.g. by moving away) and reloads, the objects will reappear.
 

--- a/ENTITY/RemoveModelHide.md
+++ b/ENTITY/RemoveModelHide.md
@@ -5,20 +5,22 @@ ns: ENTITY
 
 ```c
 // 0xD9E3006FB3CBD765 0x993DBC10
-void REMOVE_MODEL_HIDE(cs_type(Any) float x, cs_type(Any) float y, cs_type(Any) float z, cs_type(Any) float radius, cs_type(Any) Hash model, cs_type(Any) BOOL p5);
+void REMOVE_MODEL_HIDE(cs_type(Any) float x, cs_type(Any) float y, cs_type(Any) float z, cs_type(Any) float radius, cs_type(Any) Hash model, cs_type(Any) BOOL lazy);
 ```
 
-p5 requires more research. See also [`CREATE_MODEL_HIDE`](#_0x8A97BCA30A0CE478) and [`CREATE_MODEL_SWAP`](#_0x92C47782FDA8B2A3).
+Makes all objects of the specified model that were hidden using [`CREATE_MODEL_HIDE`](#_0x8A97BCA30A0CE478) or [`CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS`](#_0x3A52AE588830BF7F) visible again.
 
-Network players do not see changes done with this.
+If lazy is false, all matching objects currently in scope are restored immediately.
+If lazy is true, objects will only reappear when their map is reloaded.
+
 
 ## Parameters
-* **x**:
-* **y**:
-* **z**:
-* **radius**: The radius specified in gta units
-* **model**: The model that you want to make visible
-* **p5**:
+* **x**: X Coordinate of the sphere center.
+* **y**: Y Coordinate of the sphere center.
+* **z**: Z Coordinate of the sphere center.
+* **radius**: Radius of the sphere.
+* **model**: The model hash to make visible again.
+* **lazy**: false to apply the change immediately.
 
 ## Examples
 ```lua


### PR DESCRIPTION
Improves documentation for CREATE_MODEL_HIDE, CREATE_MODEL_HIDE_EXCLUDING_SCRIPT_OBJECTS, and REMOVE_MODEL_HIDE. Add name and behavior fof the last parameter.