### PR TITLE
Clarify toggle parameter description for lights

### DIFF
--- a/ENTITY/SetEntityLights.md
+++ b/ENTITY/SetEntityLights.md
@@ -11,5 +11,5 @@ void SET_ENTITY_LIGHTS(Entity entity, BOOL toggle);
 
 ## Parameters
 * **entity**: 
-* **toggle**: 
+* **toggle**: To turn the lights on, set to "false". To turn the lights off, set to "true".
 


### PR DESCRIPTION
This is strange behavior since I expected `true` to mean "on" and `false` to mean "off," but it’s the other way around. I added a description for clarity and included screenshots below with a print log.

State true:
<img width="1497" height="1189" alt="image" src="https://github.com/user-attachments/assets/8e1476ec-deb9-440a-8284-7e03d87376ca" />


State false:
<img width="1561" height="1179" alt="image" src="https://github.com/user-attachments/assets/b4a7abd0-492e-4530-8573-09de997696b0" />

Snippet I created to test it quickly:
```lua
print('Spawning object')

local object = CreateObject(prop, coords.xyz, false, true, false)
print('Object spawned')

Wait(5000)

print('Setting lights on true')
SetEntityLights(object, true)

Wait(1000)

print('Setting lights on false')
SetEntityLights(object, false)
```