### PR TITLE
Clarify EXTEND_WORLD_BOUNDARY_FOR_PLAYER usage and call frequency

### DIFF
--- a/PLAYER/ExtendWorldBoundaryForPlayer.md
+++ b/PLAYER/ExtendWorldBoundaryForPlayer.md
@@ -7,7 +7,7 @@ aliases: ["0x5006D96C995A5827","_EXPAND_WORLD_LIMITS"]
 ```c
 // 0x5006D96C995A5827 0x64DDB07D
 void EXTEND_WORLD_BOUNDARY_FOR_PLAYER(float x, float y, float z);
-````
+```
 
 ```
 Appears only 3 times in the scripts, more specifically in michael1.ysc

--- a/PLAYER/ExtendWorldBoundaryForPlayer.md
+++ b/PLAYER/ExtendWorldBoundaryForPlayer.md
@@ -7,16 +7,18 @@ aliases: ["0x5006D96C995A5827","_EXPAND_WORLD_LIMITS"]
 ```c
 // 0x5006D96C995A5827 0x64DDB07D
 void EXTEND_WORLD_BOUNDARY_FOR_PLAYER(float x, float y, float z);
-```
+````
 
 ```
 Appears only 3 times in the scripts, more specifically in michael1.ysc
 -
-This can be used to prevent dying if you are "out of the world"
+Expands the playable world boundary for the player to prevent dying and to prevent a vehicle's engine from automatically being killed if they go "out of the world."
+
+Call frequency: This native does not need to be called in a loop.
 ```
 
 ## Parameters
-* **x**: 
-* **y**: 
-* **z**: 
 
+* **x**: The X coordinate of the new world boundary.
+* **y**: The Y coordinate of the new world boundary.
+* **z**: The Z coordinate (height) of the new world boundary.

--- a/PLAYER/ExtendWorldBoundaryForPlayer.md
+++ b/PLAYER/ExtendWorldBoundaryForPlayer.md
@@ -12,7 +12,7 @@ void EXTEND_WORLD_BOUNDARY_FOR_PLAYER(float x, float y, float z);
 ```
 Appears only 3 times in the scripts, more specifically in michael1.ysc
 -
-Expands the playable world boundary for the player to prevent dying and to prevent a vehicle's engine from automatically being killed if they go "out of the world."
+Expands the playable world boundary for the player to prevent dying and can be used to prevent a vehicle's engine from automatically being killed if they go "out of the world."
 
 Call frequency: This native does not need to be called in a loop.
 ```


### PR DESCRIPTION
Not sure if this is useful to specify, but 'ExtendWorldBoundaryForPlayer' doesn’t need to be called in a loop and can be used to prevent vehicle engines from dying out of bounds.