### PR TITLE
Fix description for SET_TRANSITION_TIMECYCLE_MODIFIER

### DIFF
--- a/GRAPHICS/SetTransitionTimecycleModifier.md
+++ b/GRAPHICS/SetTransitionTimecycleModifier.md
@@ -12,5 +12,5 @@ This native doesn't work like [`SetWeatherTypeTransition`](#_0x578C752848ECFA0C)
 
 ## Parameters
 * **modifierName**: The name of a timecycle
-* **transition**: The speed to transition to `modifierName`. Appears to be half-seconds (?)
+* **transition**: The speed to transition to `modifierName`. Appears to be 1/3 of seconds.
 


### PR DESCRIPTION
## What was changed
Clarified the `transition` parameter description for SET_TRANSITION_TIMECYCLE_MODIFIER.

Replaced vague wording ("Appears to be half-seconds (?)") with a more accurate value (1/3 of seconds).

## Validation
Tested in-game by applying different transition values and measuring the duration.
The timing matches ~0.33 seconds per unit.

No parameter or return types were modified.