### PR TITLE
fix(docs): broken link referencing OPEN_SEQUENCE_TASK

### DIFF
--- a/TASK/TaskPerformSequenceLocally.md
+++ b/TASK/TaskPerformSequenceLocally.md
@@ -9,7 +9,7 @@ aliases: ["0x8C33220C8D78CA0D", "_TASK_PERFORM_SEQUENCE_LOCALLY"]
 void TASK_PERFORM_SEQUENCE_LOCALLY(Ped ped, int taskSequenceId);
 ```
 
-For an example on how to use this please refer to [OPEN_SEQUENCE_TASK](#_0xE8854A4326B9E12B
+For an example on how to use this please refer to [OPEN_SEQUENCE_TASK](#_0xE8854A4326B9E12B)
 
 ## Parameters
 * **ped**: The ped to perform the sequence on


### PR DESCRIPTION
This pull request fixes a broken link referencing OPEN_SEQUENCE_TASK in [TASK_PERFORM_SEQUENCE_LOCALLY](https://docs.fivem.net/natives/?_0x8C33220C8D78CA0D) caused by an unclosed link.
