### PR TITLE
Refactor object texture variation natives docs

### DIFF
--- a/OBJECT/GetObjectTextureVariation.md
+++ b/OBJECT/GetObjectTextureVariation.md
@@ -9,8 +9,10 @@ aliases: ["0xE84EB93729C5F36A"]
 int _GET_OBJECT_TEXTURE_VARIATION(Object object);
 ```
 
+Retrieves the texture variation (tint) of the object.
 
 ## Parameters
 * **object**: 
 
 ## Return value
+Integer index of the texture variation of the object. Returns `0` on objects without applied tint

--- a/OBJECT/GetObjectTextureVariation.md
+++ b/OBJECT/GetObjectTextureVariation.md
@@ -12,7 +12,7 @@ int _GET_OBJECT_TEXTURE_VARIATION(Object object);
 Retrieves the texture variation (tint) of the object.
 
 ## Parameters
-* **object**: 
+* **object**: Target object of which the texture variation gets retrieved
 
 ## Return value
 Integer index of the texture variation of the object. Returns `0` on objects without applied tint

--- a/OBJECT/SetObjectTextureVariation.md
+++ b/OBJECT/SetObjectTextureVariation.md
@@ -9,29 +9,10 @@ aliases: ["0x971DA0055324D033","_SET_OBJECT_TEXTURE_VARIANT"]
 void _SET_OBJECT_TEXTURE_VARIATION(Object object, int textureVariation);
 ```
 
-```c
-enum eObjectPaintVariants
-{  
-	Pacific = 0,  
-	Azure = 1,  
-	Nautical = 2,  
-	Continental = 3,  
-	Battleship = 4,  
-	Intrepid = 5,  
-	Uniform = 6,  
-	Classico = 7,  
-	Mediterranean = 8,  
-	Command = 9,  
-	Mariner = 10,  
-	Ruby = 11,  
-	Vintage = 12,  
-	Pristine = 13,  
-	Merchant = 14,  
-	Voyager = 15  
-};  
-```
+Sets the texture variation of a prop. Texture variations are defined in the tint palette texture of the prop. Index starts at 0.
+Props can have up to 64 texture variations defined in their tint palette.
+Base game props which utilize tinting usually have no more than 16 variations.
 
 ## Parameters
 * **object**: 
 * **textureVariation**: 
-

--- a/OBJECT/SetObjectTextureVariation.md
+++ b/OBJECT/SetObjectTextureVariation.md
@@ -9,10 +9,10 @@ aliases: ["0x971DA0055324D033","_SET_OBJECT_TEXTURE_VARIANT"]
 void _SET_OBJECT_TEXTURE_VARIATION(Object object, int textureVariation);
 ```
 
-Sets the texture variation of a prop. Texture variations are defined in the tint palette texture of the prop. Index starts at 0.
-Props can have up to 64 texture variations defined in their tint palette.
+Sets the texture variation of a prop. Texture variations are defined in the tint palette texture of the object model.
+Props can have up to 64 texture variations defined in their tint palette. Texture variations index starts at 0.
 Base game props which utilize tinting usually have no more than 16 variations.
 
 ## Parameters
-* **object**: 
-* **textureVariation**: 
+* **object**: The target object
+* **textureVariation**: New index of the texture variation


### PR DESCRIPTION
refactor: Reworked documentation for `SetObjectTextureVariation` and `GetObjectTextureVariation` to better reflect their usage and limits