### PR TITLE
add note to IS_HELP_MESSAGE_BEING_DISPLAYED

### DIFF
--- a/HUD/IsHelpMessageBeingDisplayed.md
+++ b/HUD/IsHelpMessageBeingDisplayed.md
@@ -10,3 +10,4 @@ BOOL IS_HELP_MESSAGE_BEING_DISPLAYED();
 
 
 ## Return value
+Unlike [`IS_HELP_MESSAGE_ON_SCREEN`](#_0xDAD37F45428801AE), which takes one frame to return true after calling [`END_TEXT_COMMAND_DISPLAY_HELP`](#_0x238FFE5C7B0498A6), this native will return true instantly.


### PR DESCRIPTION
Adds a note to return value because people might be confused between the difference of this native and IsHelpMessageOnScreen