### PR TITLE
correction to my previous contribution to SetLaunchControlEnabled, and new description for currently un-named native SET_IN_STUNT_MODE (its just a hash at the moment)

### DIFF
--- a/PHYSICS/N_0x9ebd751e5787baf2.md
+++ b/PHYSICS/N_0x9ebd751e5787baf2.md
@@ -8,10 +8,67 @@ ns: PHYSICS
 void _0x9EBD751E5787BAF2(BOOL p0);
 ```
 
+Enables or disables Stunt Mode for the local client. Sets a flag alongside
+[`_SET_LAUNCH_CONTROL_ENABLED`](#_0xAA6A6098851C396F); both modes can be
+active at once. Unlike Arena Mode, Stunt Mode reduces physics simulation
+accuracy in exchange for responsiveness: collision push iterations are lowered
+from 2 to 1.
+
+When enabled:
+
+### Damage
+* Collision damage below `35.0` is reduced to zero when playing on a network
+  server. Damage from explosions, fire, and weapons is unaffected. Does not
+  apply while Arena Mode is also active.
+
+### Vehicles
+* Ground clearance bounds are kept raised while airborne, preventing vehicle
+  undersides from catching on terrain and obstacles during jumps.
+* Flight handling (glider and hover mode) is forced active even when the
+  vehicle's wings or rotors are not deployed.
+* Hover mode gravity is not disabled by the `DisableHoverModeFlight` flag.
+* The conditions for exiting hover mode back to wheel driving are relaxed:
+  the vehicle can be moderately tilted rather than requiring a near-full
+  inversion, and the speed threshold is raised from `0.1` to `4.0` m/s.
+
+### Bikes and quads
+* Bike angular inertia solver overrides are disabled.
+* The local player's bike rear wheel collision radius is raised by a factor
+  of `1.25` to reduce catching on curbs and small obstacles.
+* Amphibious quad bikes treat throttle input as forward-only while airborne.
+* Stunt track surface material applies `2.5` times the normal downforce to
+  bike and quad wheels, increasing grip on stunt ramps and tracks.
+* After leaving a stunt track surface, bike wheel impacts are briefly
+  suppressed.
+
+### Planes
+* Gravity is reduced during rolls: `1.0` when level, scaling down to `0.5`
+  when fully rolled or inverted. This makes roll-based stunts easier to
+  sustain.
+
+### Wheels and physics
+* Wheel collision sweeps do not revert to the last safe position during
+  penetrations.
+* All physics time slices perform push and constraint solving, rather than
+  only the last slice.
+
+### Other
+* Vehicle repair pickups can be collected based on deformation damage alone,
+  even when vehicle health is high.
+* Network-clone ped ragdoll impacts with their ejected-from vehicle are
+  suppressed.
+* Vehicle stats continue tracking while parachuting with a vehicle.
+* Helicopter ground-probe offset is not applied when checking proximity to the
+  ground with landing gear retracted.
+* Water-based vehicles receive additional pitch stabilization torque while
+  in water.
+* Transmission shifts from reverse to first gear are permitted while moving
+  forward at speed.
+
 ```
-SET_*
+SET_IN_STUNT_MODE(BOOL p0)
 ```
 
 ## Parameters
-* **p0**: 
+* **p0**: `true` to enable Stunt Mode, `false` to disable.
 

--- a/PHYSICS/SetLaunchControlEnabled.md
+++ b/PHYSICS/SetLaunchControlEnabled.md
@@ -8,21 +8,59 @@ aliases: ["0xAA6A6098851C396F"]
 // 0xAA6A6098851C396F
 void _SET_LAUNCH_CONTROL_ENABLED(BOOL toggle);
 ```
-Toggles "Arena Mode", a global flag that affects physics, damage, and handling for all vehicles.
+Enables or disables Arena Mode for the local client. Sets a shared flag
+alongside `SET_IN_STUNT_MODE` [`N_0x9ebd751e5787baf2`](#_0x9EBD751E5787BAF2); both modes can be active at once.
 
 When enabled:
 
-* fTractionLossMult is multiplied by 0.25, increasing grip significantly.
-* Mid-air vehicle control rotation force is increased by 50%.
-* Vehicles explode immediately when body health reaches 0.
-* Disables chain-reaction explosions for nearby vehicles.
-* Prevents engine damage from colliding with Ramp Cars.
-* Overrides the Stunt Mode ([`N_0x9ebd751e5787baf2`](#_0x9EBD751E5787BAF2)) collision protection.
-* Reduces the chance of falling off bikes/quads.
+### Traction
+* Multiplies the handling value `fTractionLossMult` by `0.25` when computing
+  the surface material grip loss. This reduces how much grip is lost to the
+  driving surface, with no effect on perfect surfaces (tarmac).
+* Skips the low-speed traction loss modifier that normally reduces grip when
+  pulling away at full throttle.
+
+### In-air control
+* Multiplies the in-air pitch and roll control force by `1.5`. This stacks with
+  vehicle-specific modifiers (e.g. Veto's `2.5` becomes `3.75`).
+
+### Damage and destruction
+* Explodes the vehicle immediately when body health reaches `0`.
+* Prevents engine damage from all sources.
+* Prevents engine damage from ramp car collisions.
+* Bypasses Stunt Mode's collision damage threshold, so small impacts still
+  deal damage while Stunt Mode is also active.
+* Skips oil leaks, fuel consumption, petrol tank fires, wheel break-off from
+  collisions, helicopter rotor damage, and explosion-from-collision while
+  enabled.
+* Fire damage spread from other burning vehicles is reduced to zero when
+  vehicle explosion chain-reaction avoidance is active.
+
+### Physics
+* Applies Z-axis damping when upward velocity exceeds `15.5` m/s, capped at
+  `250` force, to limit how far launch pads can propel vehicles.
+* Vehicle jumps are not cancelled by collision with a ball object.
+* Reference frame velocity for wheel physics uses the contacted object's
+  local speed at the contact point instead of its world velocity.
+
+### Bikes and quads
+* Restricts the "easy to land" check: the vehicle must be upright or have at
+  least one wheel in contact with a surface. If both conditions are false,
+  passengers are more likely to be knocked off bikes, quads, jet skis, and
+  amphibious quads.
+
+### Visual
+* Wheel skid trail decals are allowed to appear on building surfaces.
+
+### Related
+* Vehicle explosion chain-reaction suppression is controlled separately and
+  is not part of this native.
+* Detonation-mode handling changes (altered aftertouch, self-righting,
+  jump modifiers) were prototyped during development but never shipped.
 
 ```
 NativeDB Introduced: v1604
 ```
 
 ## Parameters
-* **toggle**:
+* **toggle**: `true` to enable Arena Mode, `false` to disable.


### PR DESCRIPTION
I found a mistake in my previous description for SetLaunchControlEnabled, for example `fTractionLossMult` isn't just multiplied by 0.25, only the effect on the grip which comes from non-perfect surfaces (like grass, dirt) is multiplied by 0.25 to reduce the change in grip. Alongside that correction I decided to make a much more detailed description update, and also added description to a related native SET_IN_STUNT_MODE which can be active at the same time as Arena Mode, and they affect each other.